### PR TITLE
The package hald has been removed for a long time.

### DIFF
--- a/libexec/rc/rc.d/firstboot
+++ b/libexec/rc/rc.d/firstboot
@@ -64,7 +64,6 @@ firstboot_start()
 				/sbin/ipfw enable firewall
 				/usr/sbin/sysrc mlogind_enable=YES
 				/usr/sbin/sysrc dbus_enable=YES
-				/usr/sbin/sysrc hald_enable=YES
 
 			echo "The following options will help you install GPU drivers. You may need to perform further x.org configuration to make them work properly"
 


### PR DESCRIPTION
Not only is there no hald service, but the hald package itself is also gone.

Fixes:		remove hald service
Sponsored by:	Chinese FreeBSD Community
Pull Request:	https://github.com/midnightbsd/src/pull/262

## Summary by Sourcery

Chores:
- Remove outdated references to hald service in system initialization scripts