### PR TITLE
Fix sql injection and improve documentation

### DIFF
--- a/lib/libmsearch/msearch_fulltext.c
+++ b/lib/libmsearch/msearch_fulltext.c
@@ -41,15 +41,17 @@ __MBSDID("$MidnightBSD: src/lib/libmsearch/msearch_fulltext.c,v 1.12 2011/08/09 
 #define MAX_INDEX_SIZE 1048576
 #define DEFAULT_RESULT_LIMIT 15
 
+static sqlite3_stmt *msearch_fulltext_prepare(sqlite3 *, msearch_query *, int);
+static char *msearch_fulltext_join_terms(msearch_query *);
+
 int
 msearch_fulltext_search(msearch_query *query, msearch_result *result) {
-        sqlite3_stmt *stmt;
+        sqlite3_stmt *stmt = NULL;
         int ret, limit;
         int i = 0;
         msearch_fulltext *idx;
         msearch_result *current;
         struct stat sb;
-        char *params;
 
 	if (query == NULL)
 		return -1;
@@ -62,61 +64,121 @@ msearch_fulltext_search(msearch_query *query, msearch_result *result) {
 		return -1;
 	
 	current = result;
-	params = msearch_fulltext_query_expand(query);
-	if (params == NULL)
-		return -1;
 
 	if (query->limit < 1)
 		limit = DEFAULT_RESULT_LIMIT;
 	else
 		limit = query->limit;
 
-	ret = msearch_db_prepare(idx->db, &stmt, "SELECT path, msearch_rank(matchinfo(data)) FROM data where %s ORDER BY msearch_rank(matchinfo(data)) DESC limit %d OFFSET 0", 	
-		params, limit);
+	stmt = msearch_fulltext_prepare(idx->db, query, limit);
+	if (stmt == NULL) {
+		msearch_fulltext_close(idx);
+		return -1;
+	}
 
-	if (ret == 0) {
-                while (1) {
-                        ret = sqlite3_step(stmt);
-                        if (ret == SQLITE_ROW) {
-                                if (i > 0) {
-                                        current->next = malloc(sizeof(msearch_result));
-                                        if (current->next == NULL) {
-                                                i = -1;
-                                                break;
-                                        }
-                                        current = current->next;
+        while (1) {
+                ret = sqlite3_step(stmt);
+                if (ret == SQLITE_ROW) {
+                        if (i > 0) {
+                                current->next = malloc(sizeof(msearch_result));
+                                if (current->next == NULL) {
+                                        i = -1;
+                                        break;
                                 }
-				current->path = strdup(sqlite3_column_text(stmt, 0));
-				current->weight = sqlite3_column_double(stmt, 1);
-                                current->filename = NULL;
-                                if (lstat(sqlite3_column_text(stmt, 0), &sb) == 0) {
-                                        if (S_ISREG(sb.st_mode)) {
-                                                current->filename = strdup(basename((char *) sqlite3_column_text(stmt, 0)));
-                                        }
-					current->size = sb.st_size;
-					current->uid = sb.st_uid;
-					current->created =  sb.st_birthtime;
-                                	current->modified = sb.st_mtime;
-					current->owner = NULL;
-                                } else {
-                                	current->size = 0; 
-                                	current->uid = -1;
-                                	current->owner = NULL;
-                                	current->created =  0;
-                                	current->modified = 0;
-				}
-                                current->next = NULL;
-                                i++;
-                        } else if (ret == SQLITE_DONE) {
-                                break;
+                                current = current->next;
                         }
+			current->path = strdup(sqlite3_column_text(stmt, 0));
+			current->weight = sqlite3_column_double(stmt, 1);
+                        current->filename = NULL;
+                        if (lstat(sqlite3_column_text(stmt, 0), &sb) == 0) {
+                                if (S_ISREG(sb.st_mode)) {
+                                        current->filename = strdup(basename((char *) sqlite3_column_text(stmt, 0)));
+                                }
+				current->size = sb.st_size;
+				current->uid = sb.st_uid;
+				current->created =  sb.st_birthtime;
+                        	current->modified = sb.st_mtime;
+				current->owner = NULL;
+                        } else {
+                        	current->size = 0; 
+                        	current->uid = -1;
+                        	current->owner = NULL;
+                        	current->created =  0;
+                        	current->modified = 0;
+			}
+                        current->next = NULL;
+                        i++;
+                } else if (ret == SQLITE_DONE) {
+                        break;
+                } else {
+                        i = -1;
+                        break;
                 }
         }
         sqlite3_finalize(stmt);
         msearch_fulltext_close(idx);
-        free(params);
 
         return i;
+}
+
+static sqlite3_stmt *
+msearch_fulltext_prepare(sqlite3 *db, msearch_query *query, int limit) {
+	sqlite3_stmt *stmt = NULL;
+	char *terms;
+
+	if (db == NULL || query == NULL)
+		return NULL;
+
+	terms = msearch_fulltext_join_terms(query);
+	if (terms == NULL)
+		return NULL;
+
+	if (sqlite3_prepare_v2(db,
+	    "SELECT path, msearch_rank(matchinfo(data)) "
+	    "FROM data WHERE data MATCH ? "
+	    "ORDER BY msearch_rank(matchinfo(data)) DESC LIMIT ? OFFSET 0",
+	    -1, &stmt, NULL) != SQLITE_OK) {
+		free(terms);
+		return NULL;
+	}
+
+	if (sqlite3_bind_text(stmt, 1, terms, -1, SQLITE_TRANSIENT) != SQLITE_OK ||
+	    sqlite3_bind_int(stmt, 2, limit) != SQLITE_OK) {
+		sqlite3_finalize(stmt);
+		free(terms);
+		return NULL;
+	}
+
+	free(terms);
+	return stmt;
+}
+
+static char *
+msearch_fulltext_join_terms(msearch_query *query) {
+	char *terms;
+	size_t terms_len = 1;
+	int i;
+
+	if (query == NULL || query->term_count < 1)
+		return NULL;
+
+	for (i = 0; i < query->term_count; i++) {
+		terms_len += strlen(query->terms[i]);
+		if (i < query->term_count - 1)
+			terms_len++;
+	}
+
+	terms = calloc(terms_len, sizeof(char));
+	if (terms == NULL)
+		return NULL;
+
+	for (i = 0; i < query->term_count; i++) {
+		strlcat(terms, query->terms[i], terms_len);
+		if (i < query->term_count - 1)
+			strlcat(terms, " ", terms_len);
+	}
+
+	return terms;
 }
 
 msearch_fulltext *
@@ -306,4 +368,3 @@ msearch_fulltext_query_expand(msearch_query *restrict query) {
 
 	return result;
 }
-

--- a/lib/libmsearch/msearch_search.c
+++ b/lib/libmsearch/msearch_search.c
@@ -37,6 +37,9 @@ __MBSDID("$MidnightBSD: src/lib/libmsearch/msearch_search.c,v 1.5 2011/08/06 23:
 
 #include "msearch_private.h"
 
+static sqlite3_stmt *msearch_search_prepare(sqlite3 *, msearch_query *);
+static int msearch_search_bind(sqlite3_stmt *, msearch_query *);
+
 int
 msearch(msearch_query *query, msearch_result *result) {
 
@@ -53,7 +56,7 @@ msearch(msearch_query *query, msearch_result *result) {
 
 int 
 msearch_search(msearch_query *query, msearch_result *result) {
-	sqlite3_stmt *stmt;
+	sqlite3_stmt *stmt = NULL;
 	int ret;
 	int i = 0;
 	msearch_index *idx;
@@ -63,59 +66,142 @@ msearch_search(msearch_query *query, msearch_result *result) {
 	struct passwd pwd;
 	struct passwd* pwdbuf;
 	uid_t uid = 0;
-	char *params;
 
 	if (query == NULL)
 		return -1;
 
 	idx = msearch_index_open(MSEARCH_DEFAULT_INDEX_FILE);
+	if (idx == NULL)
+		return -1;
 	current = result;
-	params = msearch_query_expand(query);
 
-	if (query->limit < 1)
-		ret = msearch_db_prepare(idx->db, &stmt, "SELECT * FROM files where %s", params);
-	else
-		ret = msearch_db_prepare(idx->db, &stmt, "SELECT * FROM files where %s limit %d", params, query->limit);
+	stmt = msearch_search_prepare(idx->db, query);
+	if (stmt == NULL) {
+		msearch_index_close(idx);
+		return -1;
+	}
 
-	if (ret == 0) {
-		while (1) {
-			ret = sqlite3_step(stmt);
-			if (ret == SQLITE_ROW) {
-				if (i > 0) {
-					current->next = malloc(sizeof(msearch_result));
-					if (current->next == NULL) {
-						i = -1; 
-						break;
-					}
-					current = current->next;
+	ret = msearch_search_bind(stmt, query);
+	if (ret != 0) {
+		sqlite3_finalize(stmt);
+		msearch_index_close(idx);
+		return -1;
+	}
+
+	while (1) {
+		ret = sqlite3_step(stmt);
+		if (ret == SQLITE_ROW) {
+			if (i > 0) {
+				current->next = malloc(sizeof(msearch_result));
+				if (current->next == NULL) {
+					i = -1; 
+					break;
 				}
-				current->filename = NULL;
-				if (lstat(sqlite3_column_text(stmt, 0), &sb) == 0) {
-					if (S_ISREG(sb.st_mode)) {
-						current->filename = strdup(basename((char *)sqlite3_column_text(stmt, 0)));
-					}
-				}
-				current->path = strdup(sqlite3_column_text(stmt, 0));
-				current->size = sqlite3_column_int64(stmt, 1);
-				current->uid = sqlite3_column_int(stmt, 2);
-				if ((getpwuid_r(uid, &pwd, buf, sizeof(buf), &pwdbuf)) == 0 && pwdbuf != NULL) {
-					current->owner = strdup(pwdbuf->pw_name);				
-				} else
-					current->owner = NULL;
-				current->created =  sqlite3_column_int64(stmt, 3);
-				current->modified = sqlite3_column_int64(stmt, 4);
-				current->next = NULL;
-				i++;
-			} else if (ret == SQLITE_DONE) {
-				break;
+				current = current->next;
 			}
+			current->filename = NULL;
+			if (lstat(sqlite3_column_text(stmt, 0), &sb) == 0) {
+				if (S_ISREG(sb.st_mode)) {
+					current->filename = strdup(basename((char *)sqlite3_column_text(stmt, 0)));
+				}
+			}
+			current->path = strdup(sqlite3_column_text(stmt, 0));
+			current->size = sqlite3_column_int64(stmt, 1);
+			current->uid = sqlite3_column_int(stmt, 2);
+			if ((getpwuid_r(uid, &pwd, buf, sizeof(buf), &pwdbuf)) == 0 && pwdbuf != NULL) {
+				current->owner = strdup(pwdbuf->pw_name);				
+			} else
+				current->owner = NULL;
+			current->created =  sqlite3_column_int64(stmt, 3);
+			current->modified = sqlite3_column_int64(stmt, 4);
+			current->next = NULL;
+			i++;
+		} else if (ret == SQLITE_DONE) {
+			break;
+		} else {
+			i = -1;
+			break;
 		}
 	}
 	sqlite3_finalize(stmt);
 	msearch_index_close(idx);
-	free(params);
 
 	return i;
+}
+
+static sqlite3_stmt *
+msearch_search_prepare(sqlite3 *db, msearch_query *query) {
+	sqlite3_stmt *stmt = NULL;
+	char *sql;
+	size_t sql_len;
+	size_t limit_len = 0;
+	int i;
+
+	if (db == NULL || query == NULL || query->term_count < 1)
+		return NULL;
+
+	sql_len = sizeof("SELECT * FROM files WHERE ");
+	for (i = 0; i < query->term_count; i++) {
+		sql_len += sizeof("path LIKE ?");
+		if (i < query->term_count - 1)
+			sql_len += sizeof(" AND ");
+	}
+	if (query->limit > 0) {
+		limit_len = sizeof(" LIMIT ");
+		limit_len += 11;
+	}
+	sql_len += limit_len;
+
+	sql = calloc(sql_len, sizeof(char));
+	if (sql == NULL)
+		return NULL;
+
+	strlcpy(sql, "SELECT * FROM files WHERE ", sql_len);
+	for (i = 0; i < query->term_count; i++) {
+		strlcat(sql, "path LIKE ?", sql_len);
+		if (i < query->term_count - 1)
+			strlcat(sql, " AND ", sql_len);
+	}
+	if (query->limit > 0) {
+		char limit_buf[12];
+
+		snprintf(limit_buf, sizeof(limit_buf), "%d", query->limit);
+		strlcat(sql, " LIMIT ", sql_len);
+		strlcat(sql, limit_buf, sql_len);
+	}
+
+	if (sqlite3_prepare_v2(db, sql, -1, &stmt, NULL) != SQLITE_OK)
+		stmt = NULL;
+
+	free(sql);
+
+	return stmt;
+}
+
+static int
+msearch_search_bind(sqlite3_stmt *stmt, msearch_query *query) {
+	char *pattern;
+	size_t pattern_len;
+	int i;
+
+	if (stmt == NULL || query == NULL)
+		return 1;
+
+	for (i = 0; i < query->term_count; i++) {
+		pattern_len = strlen(query->terms[i]) + 3;
+		pattern = malloc(pattern_len);
+		if (pattern == NULL)
+			return 1;
+
+		snprintf(pattern, pattern_len, "%%%s%%", query->terms[i]);
+		if (sqlite3_bind_text(stmt, i + 1, pattern, -1, SQLITE_TRANSIENT) != SQLITE_OK) {
+			free(pattern);
+			return 1;
+		}
+		free(pattern);
+	}
+
+	return 0;
 }
 
 void

--- a/lib/libmsearch/msearch_search.c
+++ b/lib/libmsearch/msearch_search.c
@@ -133,74 +133,89 @@ static sqlite3_stmt *
 msearch_search_prepare(sqlite3 *db, msearch_query *query) {
 	sqlite3_stmt *stmt = NULL;
 	char *sql;
-	size_t sql_len;
-	size_t limit_len = 0;
+	char *where = NULL;
+	int param_count;
 	int i;
 
 	if (db == NULL || query == NULL || query->term_count < 1)
 		return NULL;
 
-	sql_len = sizeof("SELECT * FROM files WHERE ");
 	for (i = 0; i < query->term_count; i++) {
-		sql_len += sizeof("path LIKE ?");
-		if (i < query->term_count - 1)
-			sql_len += sizeof(" AND ");
-	}
-	if (query->limit > 0) {
-		limit_len = sizeof(" LIMIT ");
-		limit_len += 11;
-	}
-	sql_len += limit_len;
+		char *tmp;
 
-	sql = calloc(sql_len, sizeof(char));
+		if (where == NULL) {
+			where = sqlite3_mprintf("path LIKE ?");
+		} else {
+			tmp = sqlite3_mprintf("%s AND path LIKE ?", where);
+			sqlite3_free(where);
+			where = tmp;
+		}
+
+		if (where == NULL)
+			return NULL;
+	}
+
+	if (query->limit > 0) {
+		sql = sqlite3_mprintf("SELECT * FROM files WHERE %s LIMIT ?",
+		    where);
+	} else
+		sql = sqlite3_mprintf("SELECT * FROM files WHERE %s", where);
+
+	sqlite3_free(where);
 	if (sql == NULL)
 		return NULL;
-
-	strlcpy(sql, "SELECT * FROM files WHERE ", sql_len);
-	for (i = 0; i < query->term_count; i++) {
-		strlcat(sql, "path LIKE ?", sql_len);
-		if (i < query->term_count - 1)
-			strlcat(sql, " AND ", sql_len);
-	}
-	if (query->limit > 0) {
-		char limit_buf[12];
-
-		snprintf(limit_buf, sizeof(limit_buf), "%d", query->limit);
-		strlcat(sql, " LIMIT ", sql_len);
-		strlcat(sql, limit_buf, sql_len);
-	}
 
 	if (sqlite3_prepare_v2(db, sql, -1, &stmt, NULL) != SQLITE_OK)
 		stmt = NULL;
 
-	free(sql);
+	sqlite3_free(sql);
+	if (stmt == NULL)
+		return NULL;
+
+	if (query->limit > 0) {
+		param_count = sqlite3_bind_parameter_count(stmt);
+		if (sqlite3_bind_int(stmt, param_count, query->limit) != SQLITE_OK) {
+			sqlite3_finalize(stmt);
+			return NULL;
+		}
+	}
 
 	return stmt;
 }
 
 static int
 msearch_search_bind(sqlite3_stmt *stmt, msearch_query *query) {
-	char *pattern;
-	size_t pattern_len;
+	char *pattern = NULL;
+	size_t cap = 0;
 	int i;
+	int rc;
 
 	if (stmt == NULL || query == NULL)
 		return 1;
 
 	for (i = 0; i < query->term_count; i++) {
-		pattern_len = strlen(query->terms[i]) + 3;
-		pattern = malloc(pattern_len);
-		if (pattern == NULL)
-			return 1;
+		size_t needed = strlen(query->terms[i]) + 3;
+		char *tmp;
 
-		snprintf(pattern, pattern_len, "%%%s%%", query->terms[i]);
-		if (sqlite3_bind_text(stmt, i + 1, pattern, -1, SQLITE_TRANSIENT) != SQLITE_OK) {
+		if (needed > cap) {
+			tmp = realloc(pattern, needed);
+			if (tmp == NULL) {
+				free(pattern);
+				return 1;
+			}
+			pattern = tmp;
+			cap = needed;
+		}
+
+		snprintf(pattern, cap, "%%%s%%", query->terms[i]);
+		rc = sqlite3_bind_text(stmt, i + 1, pattern, -1, SQLITE_TRANSIENT);
+		if (rc != SQLITE_OK) {
 			free(pattern);
 			return 1;
 		}
-		free(pattern);
 	}
 
+	free(pattern);
 	return 0;
 }
 

--- a/usr.bin/msearch/msearch.1
+++ b/usr.bin/msearch/msearch.1
@@ -24,7 +24,7 @@
 .\"
 .\" $MidnightBSD: src/usr.bin/batt/batt.1,v 1.5 2008/12/09 16:33:34 laffer1 Exp $
 .\"
-.Dd August 6, 2011
+.Dd April 19, 2026
 .Dt MSEARCH 1
 .Os
 .Sh NAME
@@ -38,7 +38,28 @@
 .Sh DESCRIPTION
 The
 .Nm
-command searches for files on the system using an index. The file name or
+command searches for files on the system using an index.
+By default,
+.Nm
+searches indexed pathnames.
+If
+.Fl t
+is specified, indexed file contents are searched instead.
+Multiple
+.Ar pattern
+arguments may be given.
+For pathname searches, all patterns must match the pathname.
+For full text searches, the patterns are passed to the full text matcher as a
+space-separated query.
+The
+.Fl l
+option limits the number of returned results.
+When
+.Fl t
+is used and
+.Fl l
+is not specified, the default limit is 15 results.
+The file path or
 contents of the file are checked depending on the arguments to
 .Nm
 .
@@ -50,9 +71,13 @@ Print the number of matches only.
 .It Fl l Ar number
 Limit output to
 .Ar number
-of file names and exit.
+results and exit.
 .It Fl r
-Print the rank with full text search results. 
+With
+.Fl t ,
+print the result rank before each pathname.
+The rank is written as a floating-point value with two digits after the decimal
+point, followed by a space and the pathname.
 .It Fl t
 Perform a full text search.
 .It Fl z
@@ -60,6 +85,7 @@ Print pathnames separated by an
 .Tn ASCII NUL
 character (character code 0) instead of default NL
 (newline, character code 10).
+.El
 .Sh SEE ALSO
 .Xr find 1 ,
 .Xr locate 1 ,


### PR DESCRIPTION
AI-Assisted-by: GPT 5.4

## Summary by Sourcery

Use parameterized SQLite statements for msearch path and full-text queries and update the msearch manual to better describe search modes and options.

New Features:
- Support multiple search terms by generating parameterized LIKE conditions for pathname searches.
- Support multi-term full-text queries by joining terms into a space-separated MATCH string and binding the query and limit as parameters.

Bug Fixes:
- Eliminate SQL injection risk in msearch path and full-text queries by replacing string-expanded WHERE/MATCH clauses with bound parameters.
- Improve error handling in search routines by validating inputs, checking index open failures, and aborting on SQLite prepare/bind/step errors.

Enhancements:
- Refactor msearch path and full-text search routines into helper functions for preparing and binding SQLite statements, simplifying the main search loops.

Documentation:
- Expand and clarify the msearch(1) manual to document pathname vs full-text search behavior, multi-pattern handling, default limits, and rank output format, and update the document date.