### PR TITLE
cat: add -A flag (equivalent to GNU cat -A)

### DIFF
--- a/bin/cat/cat.1
+++ b/bin/cat/cat.1
@@ -39,10 +39,9 @@
 .Nd concatenate and print files
 .Sh SYNOPSIS
 .Nm
-.Op Fl belnstuv
+.Op Fl Abelnstuv
 .Op Ar
 .Sh DESCRIPTION
-The
 .Nm
 utility reads files sequentially, writing them to the standard output.
 The
@@ -70,6 +69,15 @@ domain binding capability available in
 .Pp
 The options are as follows:
 .Bl -tag -width indent
+.It Fl A
+Display non-printing characters (see the
+.Fl v
+option), display a dollar sign
+.Pq Ql \&$
+at the end of each line, and display tab characters as
+.Ql ^I .
+Equivalent to
+.Fl et .
 .It Fl b
 Number the non-blank output lines, starting at 1.
 .It Fl e
@@ -185,7 +193,7 @@ utility is compliant with the
 specification.
 .Pp
 The flags
-.Op Fl belnstv
+.Op Fl Abelnstv
 are extensions to the specification.
 .Sh HISTORY
 A

--- a/bin/cat/cat.c
+++ b/bin/cat/cat.c
@@ -116,7 +116,7 @@ static int udom_open(const char *path, int flags);
 #ifdef BOOTSTRAP_CAT
 #define SUPPORTED_FLAGS "lu"
 #else
-#define SUPPORTED_FLAGS "belnstuv"
+#define SUPPORTED_FLAGS "Abelnstuv"
 #endif
 
 #ifndef NO_UDOM_SUPPORT
@@ -176,6 +176,9 @@ main(int argc, char *argv[])
 
 	while ((ch = getopt(argc, argv, SUPPORTED_FLAGS)) != -1)
 		switch (ch) {
+		case 'A':
+			eflag = tflag = vflag = 1;
+			break;
 		case 'b':
 			bflag = nflag = 1;	/* -b implies -n */
 			break;

--- a/bin/cat/tests/A_flag_test.sh
+++ b/bin/cat/tests/A_flag_test.sh
@@ -1,0 +1,23 @@
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Copyright (c) 2026 MidnightBSD
+#
+
+atf_test_case A_flag
+A_flag_head()
+{
+	atf_set "descr" "Verify that -A is equivalent to -et"
+}
+
+A_flag_body()
+{
+	printf "tab\tchar\nnon-print\001\nend" > input
+	atf_check -o save:expected cat -et input
+	atf_check -o file:expected cat -A input
+}
+
+atf_init_test_cases()
+{
+	atf_add_test_case A_flag
+}

--- a/bin/cat/tests/Makefile
+++ b/bin/cat/tests/Makefile
@@ -3,6 +3,8 @@ PACKAGE=	tests
 
 NETBSD_ATF_TESTS_SH=		cat_test
 
+ATF_TESTS_SH+=			A_flag_test
+
 ${PACKAGE}FILES+=		d_align.in
 ${PACKAGE}FILES+=		d_align.out
 ${PACKAGE}FILES+=		d_b_output.in


### PR DESCRIPTION
Add -A flag to cat(1) utility, which is equivalent to -et (enables vflag, eflag, and tflag). This matches the behavior of GNU cat.

Updated man page and added a new ATF test case to verify equivalence.

AI-Assisted-by: Gemini CLI <noreply@google.com>

## Summary by Sourcery

Add a new -A option to the cat(1) utility and verify its behavior with documentation and tests.

New Features:
- Introduce a -A flag to cat that combines displaying non-printing characters, marking line ends, and showing tabs as ^I, equivalent to -et.

Documentation:
- Document the new -A flag in the cat(1) man page and note it as an extension to the specification.

Tests:
- Add an ATF test to ensure cat -A output matches cat -et, and register it in the test Makefile.