### PR TITLE
Update libc ohash ABI

### DIFF
--- a/include/ohash.h
+++ b/include/ohash.h
@@ -1,9 +1,6 @@
 #ifndef OHASH_H
 #define OHASH_H
-/* $MidnightBSD: src/include/ohash.h,v 1.1 2007/03/24 07:56:45 archite Exp $ */
-/* $OpenBSD: ohash.h,v 1.7 2004/06/22 20:00:16 espie Exp $ */
-/* ex:ts=8 sw=4: 
- */
+/* $OpenBSD: src/lib/libutil/ohash.h,v 1.2 2014/06/02 18:52:03 deraadt Exp $ */
 
 /* Copyright (c) 1999, 2004 Marc Espie <espie@openbsd.org>
  *
@@ -20,27 +17,33 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-/* Open hashing support. 
+#include <sys/cdefs.h>
+
+#include <stddef.h>
+#include <stdint.h>
+
+/* Open hashing support.
  * Open hashing was chosen because it is much lighter than other hash
  * techniques, and more efficient in most cases.
  */
 
 struct ohash_info {
 	ptrdiff_t key_offset;
-	void *data;	/* user data */
-	void *(*halloc)(size_t, void *);
-	void (*hfree)(void *, size_t, void *);
+	void *data; /* user data */
+	void *(*calloc)(size_t, size_t, void *);
+	void (*free)(void *, void *);
 	void *(*alloc)(size_t, void *);
 };
 
 struct _ohash_record;
 
+/* private structure. It's there just so you can do a sizeof */
 struct ohash {
-	struct _ohash_record 	*t;
-	struct ohash_info 	info;
-	unsigned int 		size;
-	unsigned int 		total;
-	unsigned int 		deleted;
+	struct _ohash_record *t;
+	struct ohash_info info;
+	unsigned int size;
+	unsigned int total;
+	unsigned int deleted;
 };
 
 /* For this to be tweakable, we use small primitives, and leave part of the
@@ -53,12 +56,10 @@ __BEGIN_DECLS
 void ohash_init(struct ohash *, unsigned, struct ohash_info *);
 void ohash_delete(struct ohash *);
 
-unsigned int ohash_lookup_string(struct ohash *, const char *, uint32_t);
-unsigned int ohash_lookup_interval(struct ohash *, const char *,
-	    const char *, uint32_t);
-unsigned int ohash_lookup_memory(struct ohash *, const char *,
-	    size_t, uint32_t)
-		__attribute__ ((__bounded__(__string__,2,3)));
+unsigned int ohash_lookup_interval(struct ohash *, const char *, const char *,
+    uint32_t);
+unsigned int ohash_lookup_memory(struct ohash *, const char *, size_t,
+    uint32_t);
 void *ohash_find(struct ohash *, unsigned int);
 void *ohash_remove(struct ohash *, unsigned int);
 void *ohash_insert(struct ohash *, unsigned int, void *);

--- a/lib/libc/Versions.def
+++ b/lib/libc/Versions.def
@@ -53,6 +53,9 @@ FBSD_1.8 {
 MNBSD_1.5 {
 } FBSD_1.8;
 
+MNBSD_1.6 {
+} MNBSD_1.5;
+
 # This is our private namespace.  Any global interfaces that are
 # strictly for use only by other FreeBSD applications and libraries
 # are listed here.  We use a separate namespace so we can write
@@ -60,4 +63,4 @@ MNBSD_1.5 {
 #
 # Please do NOT increment the version of this namespace.
 FBSDprivate_1.0 {
-} MNBSD_1.5;
+} MNBSD_1.6;

--- a/lib/libc/ohash/Makefile.inc
+++ b/lib/libc/ohash/Makefile.inc
@@ -5,10 +5,7 @@
 # open hashing functions
 .PATH: ${.CURDIR}/ohash
 
-SRCS+=	ohash_create_entry.c ohash_delete.c ohash_do.c ohash_entries.c \
-	ohash_enum.c ohash_init.c ohash_interval.c \
-	ohash_lookup_interval.c ohash_lookup_memory.c \
-	ohash_qlookup.c ohash_qlookupi.c
+SRCS+=	ohash.c ohash_compat.c
 
 CFLAGS+=	-Iohash -Wno-cast-qual
 WARNS?=	3

--- a/lib/libc/ohash/Symbol.map
+++ b/lib/libc/ohash/Symbol.map
@@ -1,10 +1,9 @@
 /*
  */
 
-FBSD_1.0 {
+MNBSD_1.6 {
 	ohash_init;
 	ohash_delete;
-	ohash_lookup_string;
 	ohash_lookup_interval;
 	ohash_lookup_memory;
 	ohash_find;

--- a/lib/libc/ohash/ohash.c
+++ b/lib/libc/ohash/ohash.c
@@ -35,9 +35,17 @@ struct _ohash_record {
 
 /* Don't bother changing the hash table if the change is small enough.  */
 #define MINSIZE (1UL << 4)
+#define MAXSIZE ((UINT_MAX >> 1U) + 1U)
 #define MINDELETED 4
 
 static void ohash_resize(struct ohash *);
+static int ohash_size_mul_overflows(size_t, size_t);
+
+static int
+ohash_size_mul_overflows(size_t n, size_t size)
+{
+	return size != 0 && n > SIZE_MAX / size;
+}
 
 /* This handles the common case of variable length keys, where the
  * key is stored at the end of the record.
@@ -46,14 +54,24 @@ void *
 ohash_create_entry(struct ohash_info *i, const char *start, const char **end)
 {
 	char *p;
+	ptrdiff_t len;
+	size_t key_offset;
+	size_t sz;
 
 	if (!*end)
 		*end = start + strlen(start);
-	p = (i->alloc)(i->key_offset + (*end - start) + 1, i->data);
+	len = *end - start;
+	if (len < 0 || i->key_offset < 0)
+		return NULL;
+	key_offset = (size_t)i->key_offset;
+	if ((size_t)len > SIZE_MAX - key_offset - 1)
+		return NULL;
+	sz = key_offset + (size_t)len + 1;
+	p = (i->alloc)(sz, i->data);
 	if (p) {
 		// NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling)
-		memcpy(p + i->key_offset, start, *end - start);
-		p[i->key_offset + (*end - start)] = '\0';
+		memcpy(p + key_offset, start, (size_t)len);
+		p[key_offset + (size_t)len] = '\0';
 	}
 	return (void *)p;
 }
@@ -79,8 +97,8 @@ ohash_resize(struct ohash *h)
 	unsigned int i, incr;
 
 	if (4 * h->deleted < h->total) {
-		if (h->size >= (UINT_MAX >> 1U))
-			ns = UINT_MAX;
+		if (h->size >= MAXSIZE)
+			ns = MAXSIZE;
 		else
 			ns = h->size << 1U;
 	} else if (3 * h->deleted > 2 * h->total)
@@ -89,6 +107,8 @@ ohash_resize(struct ohash *h)
 		ns = h->size;
 	if (ns < MINSIZE)
 		ns = MINSIZE;
+	if (ohash_size_mul_overflows(ns, sizeof(struct _ohash_record)))
+		return;
 #ifdef STATS_HASH
 	STAT_HASH_EXPAND++;
 	STAT_HASH_SIZE += ns - h->size;
@@ -188,7 +208,10 @@ ohash_next(struct ohash *h, unsigned int *pos)
 void
 ohash_init(struct ohash *h, unsigned int size, struct ohash_info *info)
 {
-	h->size = 1UL << size;
+	if (size >= sizeof(h->size) * CHAR_BIT - 1)
+		h->size = MAXSIZE;
+	else
+		h->size = 1U << size;
 	if (h->size < MINSIZE)
 		h->size = MINSIZE;
 #ifdef STATS_HASH
@@ -201,6 +224,11 @@ ohash_init(struct ohash *h, unsigned int size, struct ohash_info *info)
 	h->info.free = info->free;
 	h->info.alloc = info->alloc;
 	h->info.data = info->data;
+	if (ohash_size_mul_overflows(h->size, sizeof(struct _ohash_record))) {
+		h->t = NULL;
+		h->total = h->deleted = 0;
+		return;
+	}
 	h->t = (h->info.calloc)(h->size, sizeof(struct _ohash_record),
 	    h->info.data);
 	h->total = h->deleted = 0;

--- a/lib/libc/ohash/ohash.c
+++ b/lib/libc/ohash/ohash.c
@@ -1,0 +1,333 @@
+/* $OpenBSD: src/lib/libutil/ohash.c,v 1.1 2014/06/02 18:52:03 deraadt Exp $ */
+
+/* Copyright (c) 1999, 2004 Marc Espie <espie@openbsd.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <sys/cdefs.h>
+
+#include <limits.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "ohash.h"
+
+struct _ohash_record {
+	uint32_t hv;
+	const char *p;
+};
+
+#define DELETED ((const char *)h)
+#define NONE (h->size)
+
+/* Don't bother changing the hash table if the change is small enough.  */
+#define MINSIZE (1UL << 4)
+#define MINDELETED 4
+
+static void ohash_resize(struct ohash *);
+
+/* This handles the common case of variable length keys, where the
+ * key is stored at the end of the record.
+ */
+void *
+ohash_create_entry(struct ohash_info *i, const char *start, const char **end)
+{
+	char *p;
+
+	if (!*end)
+		*end = start + strlen(start);
+	p = (i->alloc)(i->key_offset + (*end - start) + 1, i->data);
+	if (p) {
+		// NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling)
+		memcpy(p + i->key_offset, start, *end - start);
+		p[i->key_offset + (*end - start)] = '\0';
+	}
+	return (void *)p;
+}
+
+/* hash_delete only frees the hash structure. Use hash_first/hash_next
+ * to free entries as well.
+ */
+void
+ohash_delete(struct ohash *h)
+{
+	(h->info.free)(h->t, h->info.data);
+#ifndef NDEBUG
+	h->t = NULL;
+#endif
+}
+
+static void
+ohash_resize(struct ohash *h)
+{
+	struct _ohash_record *n;
+	size_t ns;
+	unsigned int j;
+	unsigned int i, incr;
+
+	if (4 * h->deleted < h->total) {
+		if (h->size >= (UINT_MAX >> 1U))
+			ns = UINT_MAX;
+		else
+			ns = h->size << 1U;
+	} else if (3 * h->deleted > 2 * h->total)
+		ns = h->size >> 1U;
+	else
+		ns = h->size;
+	if (ns < MINSIZE)
+		ns = MINSIZE;
+#ifdef STATS_HASH
+	STAT_HASH_EXPAND++;
+	STAT_HASH_SIZE += ns - h->size;
+#endif
+
+	n = (h->info.calloc)(ns, sizeof(struct _ohash_record), h->info.data);
+	if (!n)
+		return;
+
+	for (j = 0; j < h->size; j++) {
+		if (h->t[j].p != NULL && h->t[j].p != DELETED) {
+			i = h->t[j].hv % ns;
+			incr = ((h->t[j].hv % (ns - 2)) & ~1) + 1;
+			while (n[i].p != NULL) {
+				i += incr;
+				if (i >= ns)
+					i -= ns;
+			}
+			n[i].hv = h->t[j].hv;
+			n[i].p = h->t[j].p;
+		}
+	}
+	(h->info.free)(h->t, h->info.data);
+	h->t = n;
+	h->size = ns;
+	h->total -= h->deleted;
+	h->deleted = 0;
+}
+
+void *
+ohash_remove(struct ohash *h, unsigned int i)
+{
+	void *result = (void *)h->t[i].p;
+
+	if (result == NULL || result == DELETED)
+		return NULL;
+
+#ifdef STATS_HASH
+	STAT_HASH_ENTRIES--;
+#endif
+	h->t[i].p = DELETED;
+	h->deleted++;
+	if (h->deleted >= MINDELETED && 4 * h->deleted > h->total)
+		ohash_resize(h);
+	return result;
+}
+
+void *
+ohash_find(struct ohash *h, unsigned int i)
+{
+	if (h->t[i].p == DELETED)
+		return NULL;
+	else
+		return (void *)h->t[i].p;
+}
+
+void *
+ohash_insert(struct ohash *h, unsigned int i, void *p)
+{
+#ifdef STATS_HASH
+	STAT_HASH_ENTRIES++;
+#endif
+	if (h->t[i].p == DELETED) {
+		h->deleted--;
+		h->t[i].p = p;
+	} else {
+		h->t[i].p = p;
+		/* Arbitrary resize boundary.  Tweak if not efficient enough. */
+		if (++h->total * 4 > h->size * 3)
+			ohash_resize(h);
+	}
+	return p;
+}
+
+unsigned int
+ohash_entries(struct ohash *h)
+{
+	return h->total - h->deleted;
+}
+
+void *
+ohash_first(struct ohash *h, unsigned int *pos)
+{
+	*pos = 0;
+	return ohash_next(h, pos);
+}
+
+void *
+ohash_next(struct ohash *h, unsigned int *pos)
+{
+	for (; *pos < h->size; (*pos)++)
+		if (h->t[*pos].p != DELETED && h->t[*pos].p != NULL)
+			return (void *)h->t[(*pos)++].p;
+	return NULL;
+}
+
+void
+ohash_init(struct ohash *h, unsigned int size, struct ohash_info *info)
+{
+	h->size = 1UL << size;
+	if (h->size < MINSIZE)
+		h->size = MINSIZE;
+#ifdef STATS_HASH
+	STAT_HASH_CREATION++;
+	STAT_HASH_SIZE += h->size;
+#endif
+	/* Copy info so that caller may free it.  */
+	h->info.key_offset = info->key_offset;
+	h->info.calloc = info->calloc;
+	h->info.free = info->free;
+	h->info.alloc = info->alloc;
+	h->info.data = info->data;
+	h->t = (h->info.calloc)(h->size, sizeof(struct _ohash_record),
+	    h->info.data);
+	h->total = h->deleted = 0;
+}
+
+uint32_t
+ohash_interval(const char *s, const char **e)
+{
+	uint32_t k;
+
+	if (!*e)
+		*e = s + strlen(s);
+	if (s == *e)
+		k = 0;
+	else
+		/* NOLINTNEXTLINE(bugprone-signed-char-misuse,cert-str34-c) */
+		k = *s++;
+	while (s != *e)
+		k = ((k << 2) | (k >> 30)) ^ *s++;
+	return k;
+}
+
+unsigned int
+ohash_lookup_interval(struct ohash *h, const char *start, const char *end,
+    uint32_t hv)
+{
+	unsigned int i, incr;
+	unsigned int empty;
+
+#ifdef STATS_HASH
+	STAT_HASH_LOOKUP++;
+#endif
+	empty = NONE;
+	i = hv % h->size;
+	incr = ((hv % (h->size - 2)) & ~1) + 1;
+	while (h->t[i].p != NULL) {
+#ifdef STATS_HASH
+		STAT_HASH_LENGTH++;
+#endif
+		if (h->t[i].p == DELETED) {
+			if (empty == NONE)
+				empty = i;
+		} else if (h->t[i].hv == hv &&
+		    strncmp(h->t[i].p + h->info.key_offset, start,
+			end - start) == 0 &&
+		    (h->t[i].p + h->info.key_offset)[end - start] == '\0') {
+			if (empty != NONE) {
+				h->t[empty].hv = hv;
+				h->t[empty].p = h->t[i].p;
+				h->t[i].p = DELETED;
+				return empty;
+			} else {
+#ifdef STATS_HASH
+				STAT_HASH_POSITIVE++;
+#endif
+				return i;
+			}
+		}
+		i += incr;
+		if (i >= h->size)
+			i -= h->size;
+	}
+
+	/* Found an empty position.  */
+	if (empty != NONE)
+		i = empty;
+	h->t[i].hv = hv;
+	return i;
+}
+
+unsigned int
+ohash_lookup_memory(struct ohash *h, const char *k, size_t size, uint32_t hv)
+{
+	unsigned int i, incr;
+	unsigned int empty;
+
+#ifdef STATS_HASH
+	STAT_HASH_LOOKUP++;
+#endif
+	empty = NONE;
+	i = hv % h->size;
+	incr = ((hv % (h->size - 2)) & ~1) + 1;
+	while (h->t[i].p != NULL) {
+#ifdef STATS_HASH
+		STAT_HASH_LENGTH++;
+#endif
+		if (h->t[i].p == DELETED) {
+			if (empty == NONE)
+				empty = i;
+		} else if (h->t[i].hv == hv &&
+		    memcmp(h->t[i].p + h->info.key_offset, k, size) == 0) {
+			if (empty != NONE) {
+				h->t[empty].hv = hv;
+				h->t[empty].p = h->t[i].p;
+				h->t[i].p = DELETED;
+				return empty;
+			} else {
+#ifdef STATS_HASH
+				STAT_HASH_POSITIVE++;
+#endif
+			}
+			return i;
+		}
+		i += incr;
+		if (i >= h->size)
+			i -= h->size;
+	}
+
+	/* Found an empty position.  */
+	if (empty != NONE)
+		i = empty;
+	h->t[i].hv = hv;
+	return i;
+}
+
+unsigned int
+ohash_qlookup(struct ohash *h, const char *s)
+{
+	const char *e = NULL;
+	return ohash_qlookupi(h, s, &e);
+}
+
+unsigned int
+ohash_qlookupi(struct ohash *h, const char *s, const char **e)
+{
+	uint32_t hv;
+
+	hv = ohash_interval(s, e);
+	return ohash_lookup_interval(h, s, *e, hv);
+}

--- a/lib/libc/ohash/ohash_compat.c
+++ b/lib/libc/ohash/ohash_compat.c
@@ -18,6 +18,7 @@
 
 #include <sys/cdefs.h>
 
+#include <limits.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <stdlib.h>
@@ -47,6 +48,7 @@ struct ohash_compat {
 #define DELETED ((const char *)h)
 #define NONE (h->size)
 #define MINSIZE (1UL << 4)
+#define MAXSIZE ((UINT_MAX >> 1U) + 1U)
 #define MINDELETED 4
 
 void *ohash_create_entry_compat(struct ohash_info_compat *, const char *,
@@ -72,20 +74,39 @@ unsigned int ohash_qlookupi_compat(struct ohash_compat *, const char *,
 unsigned int ohash_qlookup_compat(struct ohash_compat *, const char *);
 
 static void ohash_resize_compat(struct ohash_compat *);
+static size_t ohash_table_size_compat(size_t);
+
+static size_t
+ohash_table_size_compat(size_t size)
+{
+	if (size > SIZE_MAX / sizeof(struct ohash_record_compat))
+		return 0;
+	return sizeof(struct ohash_record_compat) * size;
+}
 
 void *
 ohash_create_entry_compat(struct ohash_info_compat *i, const char *start,
     const char **end)
 {
 	char *p;
+	ptrdiff_t len;
+	size_t key_offset;
+	size_t sz;
 
 	if (!*end)
 		*end = start + strlen(start);
-	p = (i->alloc)(i->key_offset + (*end - start) + 1, i->data);
+	len = *end - start;
+	if (len < 0 || i->key_offset < 0)
+		return NULL;
+	key_offset = (size_t)i->key_offset;
+	if ((size_t)len > SIZE_MAX - key_offset - 1)
+		return NULL;
+	sz = key_offset + (size_t)len + 1;
+	p = (i->alloc)(sz, i->data);
 	if (p) {
 		// NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling)
-		memcpy(p + i->key_offset, start, *end - start);
-		p[i->key_offset + (*end - start)] = '\0';
+		memcpy(p + key_offset, start, (size_t)len);
+		p[key_offset + (size_t)len] = '\0';
 	}
 	return (void *)p;
 }
@@ -93,8 +114,7 @@ ohash_create_entry_compat(struct ohash_info_compat *i, const char *start,
 void
 ohash_delete_compat(struct ohash_compat *h)
 {
-	(h->info.hfree)(h->t, sizeof(struct ohash_record_compat) * h->size,
-	    h->info.data);
+	(h->info.hfree)(h->t, ohash_table_size_compat(h->size), h->info.data);
 #ifndef NDEBUG
 	h->t = NULL;
 #endif
@@ -107,20 +127,24 @@ ohash_resize_compat(struct ohash_compat *h)
 	unsigned int ns, j;
 	unsigned int i, incr;
 
-	if (4 * h->deleted < h->total)
-		ns = h->size << 1;
-	else if (3 * h->deleted > 2 * h->total)
+	if (4 * h->deleted < h->total) {
+		if (h->size >= MAXSIZE)
+			ns = MAXSIZE;
+		else
+			ns = h->size << 1U;
+	} else if (3 * h->deleted > 2 * h->total)
 		ns = h->size >> 1;
 	else
 		ns = h->size;
 	if (ns < MINSIZE)
 		ns = MINSIZE;
+	if (ohash_table_size_compat(ns) == 0)
+		return;
 #ifdef STATS_HASH
 	STAT_HASH_EXPAND++;
 	STAT_HASH_SIZE += ns - h->size;
 #endif
-	n = (h->info.halloc)(sizeof(struct ohash_record_compat) * ns,
-	    h->info.data);
+	n = (h->info.halloc)(ohash_table_size_compat(ns), h->info.data);
 	if (!n)
 		return;
 
@@ -137,8 +161,7 @@ ohash_resize_compat(struct ohash_compat *h)
 			n[i].p = h->t[j].p;
 		}
 	}
-	(h->info.hfree)(h->t, sizeof(struct ohash_record_compat) * h->size,
-	    h->info.data);
+	(h->info.hfree)(h->t, ohash_table_size_compat(h->size), h->info.data);
 	h->t = n;
 	h->size = ns;
 	h->total -= h->deleted;
@@ -216,7 +239,10 @@ void
 ohash_init_compat(struct ohash_compat *h, unsigned int size,
     struct ohash_info_compat *info)
 {
-	h->size = 1UL << size;
+	if (size >= sizeof(h->size) * CHAR_BIT - 1)
+		h->size = MAXSIZE;
+	else
+		h->size = 1U << size;
 	if (h->size < MINSIZE)
 		h->size = MINSIZE;
 #ifdef STATS_HASH
@@ -229,8 +255,13 @@ ohash_init_compat(struct ohash_compat *h, unsigned int size,
 	h->info.hfree = info->hfree;
 	h->info.alloc = info->alloc;
 	h->info.data = info->data;
-	h->t = (h->info.halloc)(sizeof(struct ohash_record_compat) * h->size,
-	    h->info.data);
+	if (ohash_table_size_compat(h->size) == 0) {
+		h->t = NULL;
+		h->size = 0;
+		h->total = h->deleted = 0;
+		return;
+	}
+	h->t = (h->info.halloc)(ohash_table_size_compat(h->size), h->info.data);
 	h->total = h->deleted = 0;
 }
 

--- a/lib/libc/ohash/ohash_compat.c
+++ b/lib/libc/ohash/ohash_compat.c
@@ -1,0 +1,387 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 1999, 2004 Marc Espie <espie@openbsd.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <sys/cdefs.h>
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+struct ohash_info_compat {
+	ptrdiff_t key_offset;
+	void *data;
+	void *(*halloc)(size_t, void *);
+	void (*hfree)(void *, size_t, void *);
+	void *(*alloc)(size_t, void *);
+};
+
+struct ohash_record_compat {
+	uint32_t hv;
+	const char *p;
+};
+
+struct ohash_compat {
+	struct ohash_record_compat *t;
+	struct ohash_info_compat info;
+	unsigned int size;
+	unsigned int total;
+	unsigned int deleted;
+};
+
+#define DELETED ((const char *)h)
+#define NONE (h->size)
+#define MINSIZE (1UL << 4)
+#define MINDELETED 4
+
+void *ohash_create_entry_compat(struct ohash_info_compat *, const char *,
+    const char **);
+void ohash_delete_compat(struct ohash_compat *);
+unsigned int ohash_lookup_string_compat(struct ohash_compat *, const char *,
+    uint32_t);
+unsigned int ohash_lookup_interval_compat(struct ohash_compat *, const char *,
+    const char *, uint32_t);
+unsigned int ohash_lookup_memory_compat(struct ohash_compat *, const char *,
+    size_t, uint32_t);
+void *ohash_find_compat(struct ohash_compat *, unsigned int);
+void *ohash_remove_compat(struct ohash_compat *, unsigned int);
+void *ohash_insert_compat(struct ohash_compat *, unsigned int, void *);
+void *ohash_first_compat(struct ohash_compat *, unsigned int *);
+void *ohash_next_compat(struct ohash_compat *, unsigned int *);
+unsigned int ohash_entries_compat(struct ohash_compat *);
+void ohash_init_compat(struct ohash_compat *, unsigned int,
+    struct ohash_info_compat *);
+uint32_t ohash_interval_compat(const char *, const char **);
+unsigned int ohash_qlookupi_compat(struct ohash_compat *, const char *,
+    const char **);
+unsigned int ohash_qlookup_compat(struct ohash_compat *, const char *);
+
+static void ohash_resize_compat(struct ohash_compat *);
+
+void *
+ohash_create_entry_compat(struct ohash_info_compat *i, const char *start,
+    const char **end)
+{
+	char *p;
+
+	if (!*end)
+		*end = start + strlen(start);
+	p = (i->alloc)(i->key_offset + (*end - start) + 1, i->data);
+	if (p) {
+		// NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling)
+		memcpy(p + i->key_offset, start, *end - start);
+		p[i->key_offset + (*end - start)] = '\0';
+	}
+	return (void *)p;
+}
+
+void
+ohash_delete_compat(struct ohash_compat *h)
+{
+	(h->info.hfree)(h->t, sizeof(struct ohash_record_compat) * h->size,
+	    h->info.data);
+#ifndef NDEBUG
+	h->t = NULL;
+#endif
+}
+
+static void
+ohash_resize_compat(struct ohash_compat *h)
+{
+	struct ohash_record_compat *n;
+	unsigned int ns, j;
+	unsigned int i, incr;
+
+	if (4 * h->deleted < h->total)
+		ns = h->size << 1;
+	else if (3 * h->deleted > 2 * h->total)
+		ns = h->size >> 1;
+	else
+		ns = h->size;
+	if (ns < MINSIZE)
+		ns = MINSIZE;
+#ifdef STATS_HASH
+	STAT_HASH_EXPAND++;
+	STAT_HASH_SIZE += ns - h->size;
+#endif
+	n = (h->info.halloc)(sizeof(struct ohash_record_compat) * ns,
+	    h->info.data);
+	if (!n)
+		return;
+
+	for (j = 0; j < h->size; j++) {
+		if (h->t[j].p != NULL && h->t[j].p != DELETED) {
+			i = h->t[j].hv % ns;
+			incr = ((h->t[j].hv % (ns - 2)) & ~1) + 1;
+			while (n[i].p != NULL) {
+				i += incr;
+				if (i >= ns)
+					i -= ns;
+			}
+			n[i].hv = h->t[j].hv;
+			n[i].p = h->t[j].p;
+		}
+	}
+	(h->info.hfree)(h->t, sizeof(struct ohash_record_compat) * h->size,
+	    h->info.data);
+	h->t = n;
+	h->size = ns;
+	h->total -= h->deleted;
+	h->deleted = 0;
+}
+
+void *
+ohash_remove_compat(struct ohash_compat *h, unsigned int i)
+{
+	void *result = (void *)h->t[i].p;
+
+	if (result == NULL || result == DELETED)
+		return NULL;
+
+#ifdef STATS_HASH
+	STAT_HASH_ENTRIES--;
+#endif
+	h->t[i].p = DELETED;
+	h->deleted++;
+	if (h->deleted >= MINDELETED && 4 * h->deleted > h->total)
+		ohash_resize_compat(h);
+	return result;
+}
+
+void *
+ohash_find_compat(struct ohash_compat *h, unsigned int i)
+{
+	if (h->t[i].p == DELETED)
+		return NULL;
+	else
+		return (void *)h->t[i].p;
+}
+
+void *
+ohash_insert_compat(struct ohash_compat *h, unsigned int i, void *p)
+{
+#ifdef STATS_HASH
+	STAT_HASH_ENTRIES++;
+#endif
+	if (h->t[i].p == DELETED) {
+		h->deleted--;
+		h->t[i].p = p;
+	} else {
+		h->t[i].p = p;
+		/* Arbitrary resize boundary.  Tweak if not efficient enough. */
+		if (++h->total * 4 > h->size * 3)
+			ohash_resize_compat(h);
+	}
+	return p;
+}
+
+unsigned int
+ohash_entries_compat(struct ohash_compat *h)
+{
+	return h->total - h->deleted;
+}
+
+void *
+ohash_first_compat(struct ohash_compat *h, unsigned int *pos)
+{
+	*pos = 0;
+	return ohash_next_compat(h, pos);
+}
+
+void *
+ohash_next_compat(struct ohash_compat *h, unsigned int *pos)
+{
+	for (; *pos < h->size; (*pos)++)
+		if (h->t[*pos].p != DELETED && h->t[*pos].p != NULL)
+			return (void *)h->t[(*pos)++].p;
+	return NULL;
+}
+
+void
+ohash_init_compat(struct ohash_compat *h, unsigned int size,
+    struct ohash_info_compat *info)
+{
+	h->size = 1UL << size;
+	if (h->size < MINSIZE)
+		h->size = MINSIZE;
+#ifdef STATS_HASH
+	STAT_HASH_CREATION++;
+	STAT_HASH_SIZE += h->size;
+#endif
+	/* Copy info so that caller may free it. */
+	h->info.key_offset = info->key_offset;
+	h->info.halloc = info->halloc;
+	h->info.hfree = info->hfree;
+	h->info.alloc = info->alloc;
+	h->info.data = info->data;
+	h->t = (h->info.halloc)(sizeof(struct ohash_record_compat) * h->size,
+	    h->info.data);
+	h->total = h->deleted = 0;
+}
+
+uint32_t
+ohash_interval_compat(const char *s, const char **e)
+{
+	uint32_t k;
+
+	if (!*e)
+		*e = s + strlen(s);
+	if (s == *e)
+		k = 0;
+	else
+		/* NOLINTNEXTLINE(bugprone-signed-char-misuse,cert-str34-c) */
+		k = *s++;
+	while (s != *e)
+		k = ((k << 2) | (k >> 30)) ^ *s++;
+	return k;
+}
+
+unsigned int
+ohash_lookup_interval_compat(struct ohash_compat *h, const char *start,
+    const char *end, uint32_t hv)
+{
+	unsigned int i, incr;
+	unsigned int empty;
+
+#ifdef STATS_HASH
+	STAT_HASH_LOOKUP++;
+#endif
+	empty = NONE;
+	i = hv % h->size;
+	incr = ((hv % (h->size - 2)) & ~1) + 1;
+	while (h->t[i].p != NULL) {
+#ifdef STATS_HASH
+		STAT_HASH_LENGTH++;
+#endif
+		if (h->t[i].p == DELETED) {
+			if (empty == NONE)
+				empty = i;
+		} else if (h->t[i].hv == hv &&
+		    strncmp(h->t[i].p + h->info.key_offset, start,
+			end - start) == 0 &&
+		    (h->t[i].p + h->info.key_offset)[end - start] == '\0') {
+			if (empty != NONE) {
+				h->t[empty].hv = hv;
+				h->t[empty].p = h->t[i].p;
+				h->t[i].p = DELETED;
+				return empty;
+			} else {
+#ifdef STATS_HASH
+				STAT_HASH_POSITIVE++;
+#endif
+				return i;
+			}
+		}
+		i += incr;
+		if (i >= h->size)
+			i -= h->size;
+	}
+
+	/* Found an empty position. */
+	if (empty != NONE)
+		i = empty;
+	h->t[i].hv = hv;
+	return i;
+}
+
+unsigned int
+ohash_lookup_memory_compat(struct ohash_compat *h, const char *k, size_t size,
+    uint32_t hv)
+{
+	unsigned int i, incr;
+	unsigned int empty;
+
+#ifdef STATS_HASH
+	STAT_HASH_LOOKUP++;
+#endif
+	empty = NONE;
+	i = hv % h->size;
+	incr = ((hv % (h->size - 2)) & ~1) + 1;
+	while (h->t[i].p != NULL) {
+#ifdef STATS_HASH
+		STAT_HASH_LENGTH++;
+#endif
+		if (h->t[i].p == DELETED) {
+			if (empty == NONE)
+				empty = i;
+		} else if (h->t[i].hv == hv &&
+		    memcmp(h->t[i].p + h->info.key_offset, k, size) == 0) {
+			if (empty != NONE) {
+				h->t[empty].hv = hv;
+				h->t[empty].p = h->t[i].p;
+				h->t[i].p = DELETED;
+				return empty;
+			} else {
+#ifdef STATS_HASH
+				STAT_HASH_POSITIVE++;
+#endif
+			}
+			return i;
+		}
+		i += incr;
+		if (i >= h->size)
+			i -= h->size;
+	}
+
+	/* Found an empty position. */
+	if (empty != NONE)
+		i = empty;
+	h->t[i].hv = hv;
+	return i;
+}
+
+unsigned int
+ohash_lookup_string_compat(struct ohash_compat *h, const char *s, uint32_t hv)
+{
+	const char *e;
+
+	e = s + strlen(s);
+	return ohash_lookup_interval_compat(h, s, e, hv);
+}
+
+unsigned int
+ohash_qlookup_compat(struct ohash_compat *h, const char *s)
+{
+	const char *e = NULL;
+	return ohash_qlookupi_compat(h, s, &e);
+}
+
+unsigned int
+ohash_qlookupi_compat(struct ohash_compat *h, const char *s, const char **e)
+{
+	uint32_t hv;
+
+	hv = ohash_interval_compat(s, e);
+	return ohash_lookup_interval_compat(h, s, *e, hv);
+}
+
+__sym_compat(ohash_init, ohash_init_compat, FBSD_1.0);
+__sym_compat(ohash_delete, ohash_delete_compat, FBSD_1.0);
+__sym_compat(ohash_lookup_string, ohash_lookup_string_compat, FBSD_1.0);
+__sym_compat(ohash_lookup_interval, ohash_lookup_interval_compat, FBSD_1.0);
+__sym_compat(ohash_lookup_memory, ohash_lookup_memory_compat, FBSD_1.0);
+__sym_compat(ohash_find, ohash_find_compat, FBSD_1.0);
+__sym_compat(ohash_remove, ohash_remove_compat, FBSD_1.0);
+__sym_compat(ohash_insert, ohash_insert_compat, FBSD_1.0);
+__sym_compat(ohash_first, ohash_first_compat, FBSD_1.0);
+__sym_compat(ohash_next, ohash_next_compat, FBSD_1.0);
+__sym_compat(ohash_entries, ohash_entries_compat, FBSD_1.0);
+__sym_compat(ohash_create_entry, ohash_create_entry_compat, FBSD_1.0);
+__sym_compat(ohash_interval, ohash_interval_compat, FBSD_1.0);
+__sym_compat(ohash_qlookupi, ohash_qlookupi_compat, FBSD_1.0);
+__sym_compat(ohash_qlookup, ohash_qlookup_compat, FBSD_1.0);


### PR DESCRIPTION
## Summary

- update libc ohash to the current OpenBSD callback contract
- add `MNBSD_1.6` default symbols for the revised ABI
- keep `FBSD_1.0` compatibility wrappers for old callers using the halloc/hfree contract
- keep `ohash_lookup_string` available only as an old compatibility symbol

## Validation

- `./.agents/skills/cppcheck-clang-format-precommit/scripts/precommit_c_sanity.sh`
- manual `clang-tidy19` over `lib/libc/ohash/ohash.c` and `lib/libc/ohash/ohash_compat.c`
- `./.agents/skills/splint-post-c-sanity/scripts/run_splint_on_staged.sh`
- `git diff --cached --check`
- `bmake -C lib/libc MK_TESTS=no`
- `readelf -D -s -W /usr/obj/usr/src/amd64.amd64/lib/libc/libc.so.7.full | grep ohash`

## Notes

Full `bmake -C lib/libc` built libc but failed later while linking existing libc tests because `-lnetbsd_pie` was unavailable for `lib/libc/tests/c063/faccessat_test.full`. The targeted `MK_TESTS=no` libc build passed.

## Summary by Sourcery

Update libc ohash to the current OpenBSD ABI while preserving backward compatibility.

New Features:
- Introduce a new ohash implementation and header aligned with the modern OpenBSD callback and allocation contract.

Enhancements:
- Replace the previous collection of ohash source files with a consolidated implementation using the updated ABI.
- Add a new compatibility layer that reimplements the old ohash interface and wires it to legacy symbol versions.
- Adjust ohash public declarations to use the new allocator callbacks and remove the public ohash_lookup_string entry point.