### PR TITLE
linuxkpi: uplift to FreeBSD 14 level to support drm-515-kmod

### DIFF
--- a/drm.md
+++ b/drm.md
@@ -1,0 +1,124 @@
+# Porting drm-515-kmod to MidnightBSD — Gap Analysis & Plan
+
+## Goal
+
+Make `graphics/drm-515-kmod` (FreeBSD's backport of the Linux 5.15 DRM stack:
+`drm.ko`, `i915kms`, `amdgpu`, `radeonkms`, `ttm`) **compile and link** against
+MidnightBSD master. The port officially requires FreeBSD **14.x** and does not
+support 13.x.
+
+**Committed scope: build + link only. Do not `kldload`.** Runtime bring-up
+(vt/newcons KMS console handoff, interrupts, suspend/resume, modesetting) is
+follow-on work, out of scope here.
+
+## Current state
+
+| Tree | Version | LinuxKPI level |
+|------|---------|----------------|
+| MidnightBSD master (`/usr/src`) | `__MidnightBSD_version 401002`, `__FreeBSD_version 1305500` | ad-hoc fork, ~FreeBSD **13.5-STABLE** with selective forward-ports |
+| FreeBSD 14-STABLE (`/home/laffer1/git/freebsd`, `stable/14`) | `__FreeBSD_version 1404501` | reference target |
+
+MidnightBSD's `sys/compat/linuxkpi` is **not** a clean FreeBSD checkout. Its git
+history is a sequence of partial manual imports (FreeBSD 12-stable → 13-stable →
+13.5), including a DRM-motivated `THIS_MODULE` fix — so it already carries some
+14-era symbols (`pci_domain_nr`, `lkpi_pci_get_domain_bus_and_slot`) but lacks a
+coherent 14-level baseline.
+
+## Key finding that reframes the gap
+
+`dma-buf.h`, `dma-fence.h`, `dma-resv.h` are **absent from both** MidnightBSD and
+FreeBSD 14 base LinuxKPI. They are **shipped by the drm-kmod port itself** (its
+bundled GPLv2 headers). They are therefore **not** base-kernel gaps — an initial
+read that flagged them as "blocking" was wrong. The real gap is the LinuxKPI
+delta between MidnightBSD (~13.5) and FreeBSD 14-STABLE.
+
+The file-level diff below is a **floor**, not the full gap: the port also relies
+on intra-file API additions inside headers MidnightBSD already has.
+
+### Missing headers (`sys/compat/linuxkpi/common/include/linux/`)
+
+`aperture.h`, `iosys-map.h`, `hdmi.h`, `iommu.h`, `irqdomain.h`, `ioport.h`,
+`io-64-nonatomic-lo-hi.h`, `cleanup.h`, `container_of.h`, `build_bug.h`,
+`minmax.h`, `math.h`, `limits.h`, `kstrtox.h`, `string_helpers.h`, `nodemask.h`,
+`dynamic_debug.h`, `of.h`, `agp_backend.h`, `apple-gmux.h`, the `device/`
+subdir, plus the `kunit/` and `xen/` include trees.
+
+### Missing sources (`sys/compat/linuxkpi/common/src/`)
+
+`linux_aperture.c`, `linux_cmdline.c`, `linux_hdmi.c`, `linux_kobject.c`,
+`linuxkpi_hdmikmod.c`, `linuxkpi_videokmod.c` (HDMI infoframe + ACPI
+video/backlight modules the DRM drivers link against).
+
+### Intra-file deltas to re-sync to 14-STABLE
+
+`pci.h` / `linux_pci.c` (the port's `extra-patch-linuxkpi-pci`, gated
+`>=1403508`, assumes the 14-era `to_pci_dev(dev->dev)->bus` + `pci_domain_nr`
+shape), `iosys-map.h` (replaces the older `dma-buf-map.h`), `mm.h`, `device.h`,
+`shrinker.h`.
+
+### Already present — no work needed
+
+`sys/dev/vt` (newcons + `hw/fb` `vt_fb` + `hw/efifb`), `sys/dev/drm2/ttm`,
+`sys/dev/acpica`, and the build glue in `sys/conf/kmod.mk`
+(`LINUXKPI_GENSRCS` / `LINUXKPI_INCLUDES` already match FreeBSD 14).
+
+## Plan
+
+Two independent workstreams.
+
+### A. LinuxKPI uplift to FreeBSD 14-STABLE (in `/usr/src`)
+
+**Wholesale vendor import** of FreeBSD 14-STABLE's `sys/compat/linuxkpi` via the
+repo's vendor-import workflow, establishing a clean 14-level baseline, then fix
+base-kernel build breaks. Chosen over cherry-picking the ~28 missing files
+because the port also depends on intra-file API additions, and the existing
+ad-hoc state is harder to reason about than a clean re-baseline.
+
+**Base-kernel dependency reconciliation** (where the real effort/risk is). The
+14-level LinuxKPI calls base facilities that evolved 13.5→14. Iterate until the
+modules link:
+
+1. Build kernel + modules; collect undefined-symbol / signature errors.
+2. For each, grep the FreeBSD 14 implementation for the base call
+   (`vm_page`/pctrie, `bus_dma`, `taskqueue`, `sysctl`, `kobject`/sysfs, fbio)
+   and confirm it exists at the right signature in `/usr/src/sys`.
+3. Backport the minimal base KPI (or shim it) as separate, reviewable commits.
+
+### B. Make the port recognize MidnightBSD (in `/usr/ports/graphics/`)
+
+Patch the port Makefile locally rather than bumping `__FreeBSD_version`
+(version bump = repo-wide blast radius). In
+`/usr/ports/graphics/drm-515-kmod/Makefile` (and the `drm-kmod` meta-port as
+needed):
+
+- Drop/adjust the `OPSYS != FreeBSD` → `IGNORE` guard so MidnightBSD is allowed.
+- Gate the `OSVERSION` / `extra-patch-linuxkpi-pci` branches on a MidnightBSD
+  capability condition (e.g. `__MidnightBSD_version`) instead of `1403508` /
+  `1500065`, so the PCI patch applies given our 14-level `pci.h`.
+- Confirm `USES=kmod` finds `SRC_BASE=/usr/src/sys/Makefile`; build
+  `gpu-firmware-kmod` (firmware-only, low risk).
+
+## Critical files
+
+- `/usr/src/sys/compat/linuxkpi/common/{include,src}/` — import target (A)
+- `/usr/src/sys/sys/param.h` — version constants (read; bump only if route B changes)
+- `/usr/src/sys/conf/kmod.mk` — build glue (verify; already 14-aligned)
+- `/home/laffer1/git/freebsd/sys/compat/linuxkpi/` — FreeBSD 14-STABLE source of truth
+- `/usr/ports/graphics/drm-515-kmod/{Makefile,Makefile.version,files/extra-patch-linuxkpi-pci}`
+- `/usr/ports/graphics/drm-kmod/Makefile`, `/usr/ports/graphics/gpu-firmware-kmod/`
+
+## Verification (build-only; do NOT kldload)
+
+1. `cd /usr/src && make buildkernel` — kernel + in-tree LinuxKPI compile clean
+   after import + dependency fixes.
+2. `cd /usr/ports/graphics/drm-515-kmod && make` — port no longer `IGNORE`s and
+   compiles; confirm `work/.../{drm,i915kms,amdgpu,radeonkms,ttm}.ko` produced.
+3. Static link sanity: `nm -u` on the `.ko`s to confirm no unresolved LinuxKPI
+   symbols against the built kernel. **No `kldload`.**
+4. Run the C precommit sanity (cppcheck / clang-format) on base-kernel shim
+   commits.
+
+## Out of scope (follow-on)
+
+`kldload`, vt/newcons KMS console handoff, interrupt routing, suspend/resume,
+on-hardware modesetting.

--- a/drm.md
+++ b/drm.md
@@ -4,121 +4,85 @@
 
 Make `graphics/drm-515-kmod` (FreeBSD's backport of the Linux 5.15 DRM stack:
 `drm.ko`, `i915kms`, `amdgpu`, `radeonkms`, `ttm`) **compile and link** against
-MidnightBSD master. The port officially requires FreeBSD **14.x** and does not
-support 13.x.
+MidnightBSD master. The port officially requires FreeBSD **14.x**.
 
 **Committed scope: build + link only. Do not `kldload`.** Runtime bring-up
 (vt/newcons KMS console handoff, interrupts, suspend/resume, modesetting) is
-follow-on work, out of scope here.
+out of scope.
 
 ## Current state
 
 | Tree | Version | LinuxKPI level |
 |------|---------|----------------|
-| MidnightBSD master (`/usr/src`) | `__MidnightBSD_version 401002`, `__FreeBSD_version 1305500` | ad-hoc fork, ~FreeBSD **13.5-STABLE** with selective forward-ports |
+| MidnightBSD master (`/usr/src`) | `__MidnightBSD_version 401002`, `__FreeBSD_version 1305500` | ad-hoc fork, ~FreeBSD **13.5-STABLE** + selective forward-ports |
 | FreeBSD 14-STABLE (`/home/laffer1/git/freebsd`, `stable/14`) | `__FreeBSD_version 1404501` | reference target |
 
-MidnightBSD's `sys/compat/linuxkpi` is **not** a clean FreeBSD checkout. Its git
-history is a sequence of partial manual imports (FreeBSD 12-stable → 13-stable →
-13.5), including a DRM-motivated `THIS_MODULE` fix — so it already carries some
-14-era symbols (`pci_domain_nr`, `lkpi_pci_get_domain_bus_and_slot`) but lacks a
-coherent 14-level baseline.
+MidnightBSD's `sys/compat/linuxkpi` is a series of ad-hoc partial imports from
+FreeBSD 12 → 13 → 13.5, already partly forward-ported (e.g. `pci_domain_nr`).
 
-## Key finding that reframes the gap
+## Key findings
 
-`dma-buf.h`, `dma-fence.h`, `dma-resv.h` are **absent from both** MidnightBSD and
-FreeBSD 14 base LinuxKPI. They are **shipped by the drm-kmod port itself** (its
-bundled GPLv2 headers). They are therefore **not** base-kernel gaps — an initial
-read that flagged them as "blocking" was wrong. The real gap is the LinuxKPI
-delta between MidnightBSD (~13.5) and FreeBSD 14-STABLE.
+1. **`dma-buf.h` / `dma-fence.h` / `dma-resv.h` are NOT base gaps.** They are
+   absent from *both* MidnightBSD and FreeBSD 14 base LinuxKPI — the drm-kmod
+   **port ships them itself** (bundled GPLv2 headers). Not our problem to add.
 
-The file-level diff below is a **floor**, not the full gap: the port also relies
-on intra-file API additions inside headers MidnightBSD already has.
+2. **A wholesale FreeBSD 14 LinuxKPI import is the WRONG approach.** Empirically
+   verified: overlaying FreeBSD 14's `common/{include,src}` and building fails on
+   **base-kernel API deltas** that recur in nearly every file —
+   - `sched.h` → `td_ast_pending` / `TDA_SCHED` (FreeBSD 14 **AST framework**)
+   - `net.h` → `pr_peeraddr` / `pr_sockaddr` (FreeBSD 14 **protosw refactor**)
+   - `file.h` / `linux_compat.c` → `fget_unlocked`, `fo_stat_t`, const `fileops`
+   - `rbtree.h` (`sys/tree.h` macro arity), `kmem_free(void*)`, `qsort_r`
+   MidnightBSD's base has **none** of these. Wholesale import would require
+   backporting the AST framework, the protosw refactor, and the file/fileops
+   API into MidnightBSD's base kernel — a larger, riskier project than the drm
+   port itself, destabilizing unrelated subsystems.
 
-### Missing headers (`sys/compat/linuxkpi/common/include/linux/`)
+3. **MidnightBSD's existing LinuxKPI already correctly targets its 13.5 base.**
+   The real gap is the *additive* FreeBSD 14 files (new headers + new modules),
+   not re-importing existing files.
 
-`aperture.h`, `iosys-map.h`, `hdmi.h`, `iommu.h`, `irqdomain.h`, `ioport.h`,
-`io-64-nonatomic-lo-hi.h`, `cleanup.h`, `container_of.h`, `build_bug.h`,
-`minmax.h`, `math.h`, `limits.h`, `kstrtox.h`, `string_helpers.h`, `nodemask.h`,
-`dynamic_debug.h`, `of.h`, `agp_backend.h`, `apple-gmux.h`, the `device/`
-subdir, plus the `kunit/` and `xen/` include trees.
+## Approach: hybrid (additive import + targeted backports)
 
-### Missing sources (`sys/compat/linuxkpi/common/src/`)
+Keep MidnightBSD's existing, base-compatible LinuxKPI files. Add only the
+genuinely-new FreeBSD 14 pieces drm needs, and backport individual new symbols
+into existing headers only where they don't drag base-incompatible changes.
 
-`linux_aperture.c`, `linux_cmdline.c`, `linux_hdmi.c`, `linux_kobject.c`,
-`linuxkpi_hdmikmod.c`, `linuxkpi_videokmod.c` (HDMI infoframe + ACPI
-video/backlight modules the DRM drivers link against).
+### Workstream A — LinuxKPI uplift (in `/usr/src`)  — IN PROGRESS
 
-### Intra-file deltas to re-sync to 14-STABLE
+- [x] Import additive FreeBSD 14 headers (`aperture.h`, `iosys-map.h`, `hdmi.h`,
+      `iommu.h`, `irqdomain.h`, `ioport.h`, `io-64-nonatomic-lo-hi.h`,
+      `cleanup.h`, `container_of.h`, `build_bug.h`, `minmax.h`, `math.h`,
+      `limits.h`, `kstrtox.h`, `string_helpers.h`, `nodemask.h`, `of.h`,
+      `agp_backend.h`, `apple-gmux.h`, `device/`, `video/`, dummy `sysfb.h`).
+- [x] Add `linuxkpi_hdmi` and `linuxkpi_video` modules (HDMI infoframe,
+      ACPI-video/backlight, framebuffer aperture) + register in
+      `sys/modules/Makefile`. **Both build clean.**
+- [x] Backport `devm_add_action()/devm_add_action_or_reset()` (needed by
+      `linux_aperture.c`).
+- [ ] Backport further individual symbols as the drm port build demands them
+      (iterative, localized — keep MidnightBSD base semantics, do NOT pull the
+      AST/protosw/file base reworks).
+- Note: `linux_kobject.c` is intentionally NOT imported — FreeBSD 14 split it
+  out of `linux_compat.c`, which MidnightBSD still carries inline (would dup).
 
-`pci.h` / `linux_pci.c` (the port's `extra-patch-linuxkpi-pci`, gated
-`>=1403508`, assumes the 14-era `to_pci_dev(dev->dev)->bus` + `pci_domain_nr`
-shape), `iosys-map.h` (replaces the older `dma-buf-map.h`), `mm.h`, `device.h`,
-`shrinker.h`.
+### Workstream B — Port recognizes MidnightBSD (in `/usr/ports/graphics/`) — TODO
 
-### Already present — no work needed
-
-`sys/dev/vt` (newcons + `hw/fb` `vt_fb` + `hw/efifb`), `sys/dev/drm2/ttm`,
-`sys/dev/acpica`, and the build glue in `sys/conf/kmod.mk`
-(`LINUXKPI_GENSRCS` / `LINUXKPI_INCLUDES` already match FreeBSD 14).
-
-## Plan
-
-Two independent workstreams.
-
-### A. LinuxKPI uplift to FreeBSD 14-STABLE (in `/usr/src`)
-
-**Wholesale vendor import** of FreeBSD 14-STABLE's `sys/compat/linuxkpi` via the
-repo's vendor-import workflow, establishing a clean 14-level baseline, then fix
-base-kernel build breaks. Chosen over cherry-picking the ~28 missing files
-because the port also depends on intra-file API additions, and the existing
-ad-hoc state is harder to reason about than a clean re-baseline.
-
-**Base-kernel dependency reconciliation** (where the real effort/risk is). The
-14-level LinuxKPI calls base facilities that evolved 13.5→14. Iterate until the
-modules link:
-
-1. Build kernel + modules; collect undefined-symbol / signature errors.
-2. For each, grep the FreeBSD 14 implementation for the base call
-   (`vm_page`/pctrie, `bus_dma`, `taskqueue`, `sysctl`, `kobject`/sysfs, fbio)
-   and confirm it exists at the right signature in `/usr/src/sys`.
-3. Backport the minimal base KPI (or shim it) as separate, reviewable commits.
-
-### B. Make the port recognize MidnightBSD (in `/usr/ports/graphics/`)
-
-Patch the port Makefile locally rather than bumping `__FreeBSD_version`
-(version bump = repo-wide blast radius). In
-`/usr/ports/graphics/drm-515-kmod/Makefile` (and the `drm-kmod` meta-port as
-needed):
-
-- Drop/adjust the `OPSYS != FreeBSD` → `IGNORE` guard so MidnightBSD is allowed.
-- Gate the `OSVERSION` / `extra-patch-linuxkpi-pci` branches on a MidnightBSD
-  capability condition (e.g. `__MidnightBSD_version`) instead of `1403508` /
-  `1500065`, so the PCI patch applies given our 14-level `pci.h`.
+Patch `graphics/drm-515-kmod` (and `drm-kmod` meta-port) locally rather than
+bumping `__FreeBSD_version`:
+- Drop the `OPSYS != FreeBSD` → `IGNORE` guard.
+- Gate `OSVERSION` / `extra-patch-linuxkpi-pci` on `__MidnightBSD_version`.
 - Confirm `USES=kmod` finds `SRC_BASE=/usr/src/sys/Makefile`; build
-  `gpu-firmware-kmod` (firmware-only, low risk).
-
-## Critical files
-
-- `/usr/src/sys/compat/linuxkpi/common/{include,src}/` — import target (A)
-- `/usr/src/sys/sys/param.h` — version constants (read; bump only if route B changes)
-- `/usr/src/sys/conf/kmod.mk` — build glue (verify; already 14-aligned)
-- `/home/laffer1/git/freebsd/sys/compat/linuxkpi/` — FreeBSD 14-STABLE source of truth
-- `/usr/ports/graphics/drm-515-kmod/{Makefile,Makefile.version,files/extra-patch-linuxkpi-pci}`
-- `/usr/ports/graphics/drm-kmod/Makefile`, `/usr/ports/graphics/gpu-firmware-kmod/`
+  `gpu-firmware-kmod`.
 
 ## Verification (build-only; do NOT kldload)
 
-1. `cd /usr/src && make buildkernel` — kernel + in-tree LinuxKPI compile clean
-   after import + dependency fixes.
-2. `cd /usr/ports/graphics/drm-515-kmod && make` — port no longer `IGNORE`s and
-   compiles; confirm `work/.../{drm,i915kms,amdgpu,radeonkms,ttm}.ko` produced.
-3. Static link sanity: `nm -u` on the `.ko`s to confirm no unresolved LinuxKPI
-   symbols against the built kernel. **No `kldload`.**
-4. Run the C precommit sanity (cppcheck / clang-format) on base-kernel shim
-   commits.
+1. `cd /usr/src/sys/modules/linuxkpi{,_hdmi,_video} && make` — clean. (done)
+2. `cd /usr/ports/graphics/drm-515-kmod && make` — no `IGNORE`; produces
+   `drm/i915kms/amdgpu/radeonkms/ttm .ko`.
+3. `nm -u` the `.ko`s for unresolved LinuxKPI symbols against the built kernel.
+4. cppcheck/clang-format sanity on any base-compat backport commits.
 
 ## Out of scope (follow-on)
-
-`kldload`, vt/newcons KMS console handoff, interrupt routing, suspend/resume,
+`kldload`, vt/newcons KMS console handoff, interrupts, suspend/resume,
 on-hardware modesetting.

--- a/drm.md
+++ b/drm.md
@@ -66,14 +66,21 @@ into existing headers only where they don't drag base-incompatible changes.
 - Note: `linux_kobject.c` is intentionally NOT imported — FreeBSD 14 split it
   out of `linux_compat.c`, which MidnightBSD still carries inline (would dup).
 
-### Workstream B — Port recognizes MidnightBSD (in `/usr/ports/graphics/`) — TODO
+### Workstream B — Create drm-515-kmod in mports (in `/usr/mports`) — TODO
 
-Patch `graphics/drm-515-kmod` (and `drm-kmod` meta-port) locally rather than
-bumping `__FreeBSD_version`:
-- Drop the `OPSYS != FreeBSD` → `IGNORE` guard.
-- Gate `OSVERSION` / `extra-patch-linuxkpi-pci` on `__MidnightBSD_version`.
-- Confirm `USES=kmod` finds `SRC_BASE=/usr/src/sys/Makefile`; build
-  `gpu-firmware-kmod`.
+NOTE: `/usr/ports` here is the upstream **FreeBSD** ports tree and is not
+operational under MidnightBSD make (`bsd.port.options.mk` not found,
+`${OPSYS}` conditionals malformed). MidnightBSD uses **mports** at
+`/usr/mports`, which already ships a MidnightBSD-adapted `graphics/drm-510-kmod`
+(uses `bsd.mport.options.mk`, `IGNORE_MidnightBSD_3.x`, already
+`CONFLICTS_INSTALL` with `drm-515-kmod`) and `gpu-firmware-kmod`.
+
+- Create `graphics/drm-515-kmod` by copying mports `drm-510-kmod` and bumping
+  `Makefile.version` to 5.15.160 / `drm_v5.15.160_6`; refresh `distinfo`,
+  `pkg-plist`, and the `extra-patch-linuxkpi-pci` (gate decided by build).
+- Build via mports against `/usr/src` (our uplifted LinuxKPI); iterate
+  base-compat backports (Workstream A) as drm source demands them.
+- mports is a separate git repo (MidnightBSD/mports) → a second PR.
 
 ## Verification (build-only; do NOT kldload)
 

--- a/drm.md
+++ b/drm.md
@@ -93,3 +93,37 @@ operational under MidnightBSD make (`bsd.port.options.mk` not found,
 ## Out of scope (follow-on)
 `kldload`, vt/newcons KMS console handoff, interrupts, suspend/resume,
 on-hardware modesetting.
+
+## Result — DONE (build + link verified)
+
+All six modules build and link clean against MidnightBSD (`__FreeBSD_version
+1305500`) on amd64, via `cd /usr/mports/graphics/drm-515-kmod && make build
+SRC_BASE=/usr/src`:
+
+    dmabuf.ko  drm.ko  ttm.ko  amdgpu.ko  i915kms.ko  radeonkms.ko
+
+(All valid `ELF 64-bit LSB relocatable` kmods. Not loaded — out of scope.)
+
+### LinuxKPI changes (src branch `feature/drm-515-kmod-linuxkpi`)
+Additive FreeBSD 14 import (headers + linuxkpi_hdmi/linuxkpi_video modules)
+plus targeted backports, each driven by a real build failure:
+- single-arg `vm_operations_struct.fault`; `kernel.h`→`math64.h`
+- `devm_add_action()/_or_reset()`; `pcie_aspm_enabled()`; INTEL_FAM6 Alder Lake
+- `noinline_for_stack`; `bitmap_to_arr32()`; `acpi_put_table()`
+- move BUILD_BUG → `build_bug.h`; move U*_MAX → `limits.h` (both included from kernel.h)
+- self-contained `dmi.h` errno; import `util_macros.h`, `time64.h`
+- tasklet callback API (`tasklet_setup`, `from_tasklet`, `->callback`) + `ZERO_SIZE_PTR`
+- PCI/device power bits (`dev_pm_info`, `pci_dev.current_state`,
+  `pci_power_name()`, `pci_power_names[]`)
+
+Existing LinuxKPI files were intentionally NOT re-imported wholesale (would
+require backporting the FreeBSD 14 AST/protosw/file base reworks).
+
+### Port (mports branch `feature/drm-515-kmod`)
+`graphics/drm-515-kmod` from drm-510-kmod; two source patches for FreeBSD-14
+assumptions vs MidnightBSD base (`dma_buf_stat` thread arg; i915
+`totalram_pages` gated on `__MidnightBSD_version`).
+
+### Not done (follow-on)
+`kldload` and runtime bring-up (vt/newcons KMS handoff, IRQs, suspend/resume,
+modesetting); powerpc64 `acpi_iicbus` guard; gpu-firmware-kmod packaging.

--- a/sys/compat/linuxkpi/common/include/acpi/acpi.h
+++ b/sys/compat/linuxkpi/common/include/acpi/acpi.h
@@ -95,4 +95,10 @@ acpi_get_table(ACPI_STRING Signature, UINT32 Instance,
 	return (AcpiGetTable(Signature, Instance, OutTable));
 }
 
+static inline void
+acpi_put_table(ACPI_TABLE_HEADER *Table)
+{
+	AcpiPutTable(Table);
+}
+
 #endif /* _LINUXKPI_ACPI_ACPI_H_ */

--- a/sys/compat/linuxkpi/common/include/asm/hypervisor.h
+++ b/sys/compat/linuxkpi/common/include/asm/hypervisor.h
@@ -1,0 +1,19 @@
+/* Public domain. */
+
+#ifndef _LINUXKPI_ASM_HYPERVISOR_H
+#define _LINUXKPI_ASM_HYPERVISOR_H
+
+#if defined(__i386__) || defined(__amd64__)
+
+#define X86_HYPER_NATIVE	1
+#define X86_HYPER_MS_HYPERV	2
+
+static inline bool
+hypervisor_is_type(int type)
+{
+	return (type == X86_HYPER_NATIVE);
+}
+
+#endif
+
+#endif

--- a/sys/compat/linuxkpi/common/include/asm/intel-family.h
+++ b/sys/compat/linuxkpi/common/include/asm/intel-family.h
@@ -1,3 +1,6 @@
 /* Public domain. */
 
+#define	INTEL_FAM6_ALDERLAKE	0x97
+#define	INTEL_FAM6_ALDERLAKE_L	0x9A
+
 #define	INTEL_FAM6_ROCKETLAKE	0xA7

--- a/sys/compat/linuxkpi/common/include/asm/memtype.h
+++ b/sys/compat/linuxkpi/common/include/asm/memtype.h
@@ -1,0 +1,18 @@
+/* Public domain. */
+
+#ifndef _LINUXKPI_ASM_MEMTYPE_H_
+#define _LINUXKPI_ASM_MEMTYPE_H_
+
+#if defined(__amd64__) || defined(__i386__)
+
+#include <asm/cpufeature.h>
+
+static inline bool
+pat_enabled(void)
+{
+	return (boot_cpu_has(X86_FEATURE_PAT));
+}
+
+#endif
+
+#endif /* _LINUXKPI_ASM_MEMTYPE_H_ */

--- a/sys/compat/linuxkpi/common/include/asm/neon.h
+++ b/sys/compat/linuxkpi/common/include/asm/neon.h
@@ -1,0 +1,40 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2022 Val Packett <val@packett.cool>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHORS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#ifndef	_LINUXKPI_ASM_NEON_H_
+#define	_LINUXKPI_ASM_NEON_H_
+
+#define	kernel_neon_begin() \
+   lkpi_kernel_fpu_begin()
+
+#define	kernel_neon_end() \
+   lkpi_kernel_fpu_end()
+
+extern void lkpi_kernel_fpu_begin(void);
+extern void lkpi_kernel_fpu_end(void);
+
+#endif /* _LINUXKPI_ASM_NEON_H_ */

--- a/sys/compat/linuxkpi/common/include/kunit/static_stub.h
+++ b/sys/compat/linuxkpi/common/include/kunit/static_stub.h
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2025 The FreeBSD Foundation
+ *
+ * This software was developed by Björn Zeeb under sponsorship from
+ * the FreeBSD Foundation.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#ifndef	_LINUXKPI_KUNIT_STATIC_STUB_H
+#define	_LINUXKPI_KUNIT_STATIC_STUB_H
+
+#define	KUNIT_STATIC_STUB_REDIRECT(_fn, ...)	do { } while(0)
+
+#endif	/* _LINUXKPI_KUNIT_STATIC_STUB_H */

--- a/sys/compat/linuxkpi/common/include/linux/agp_backend.h
+++ b/sys/compat/linuxkpi/common/include/linux/agp_backend.h
@@ -1,0 +1,28 @@
+/* Public domain */
+
+#ifndef _LINUXKPI_LINUX_AGP_BACKEND_H_
+#define	_LINUXKPI_LINUX_AGP_BACKEND_H_
+
+#include <sys/types.h>
+
+struct agp_version {
+	uint16_t	major;
+	uint16_t	minor;
+};
+
+struct agp_kern_info {
+	struct agp_version	version;
+	uint16_t		vendor;
+	uint16_t		device;
+	unsigned long		mode;
+	unsigned long		aper_base;
+	size_t			aper_size;
+	int			max_memory;
+	int			current_memory;
+	bool			cant_use_aperture;
+	unsigned long		page_mask;
+};
+
+struct agp_memory;
+
+#endif /* _LINUXKPI_LINUX_AGP_BACKEND_H_ */

--- a/sys/compat/linuxkpi/common/include/linux/aperture.h
+++ b/sys/compat/linuxkpi/common/include/linux/aperture.h
@@ -1,0 +1,64 @@
+/* SPDX-License-Identifier: MIT */
+
+#ifndef _LINUX_APERTURE_H_
+#define _LINUX_APERTURE_H_
+
+#include <linux/types.h>
+
+#define	CONFIG_APERTURE_HELPERS
+
+struct pci_dev;
+struct platform_device;
+
+#if defined(CONFIG_APERTURE_HELPERS)
+int devm_aperture_acquire_for_platform_device(struct platform_device *pdev,
+					      resource_size_t base,
+					      resource_size_t size);
+
+int aperture_remove_conflicting_devices(resource_size_t base, resource_size_t size,
+					const char *name);
+
+int __aperture_remove_legacy_vga_devices(struct pci_dev *pdev);
+
+int aperture_remove_conflicting_pci_devices(struct pci_dev *pdev, const char *name);
+#else
+static inline int devm_aperture_acquire_for_platform_device(struct platform_device *pdev,
+							    resource_size_t base,
+							    resource_size_t size)
+{
+	return 0;
+}
+
+static inline int aperture_remove_conflicting_devices(resource_size_t base, resource_size_t size,
+						      const char *name)
+{
+	return 0;
+}
+
+static inline int __aperture_remove_legacy_vga_devices(struct pci_dev *pdev)
+{
+	return 0;
+}
+
+static inline int aperture_remove_conflicting_pci_devices(struct pci_dev *pdev, const char *name)
+{
+	return 0;
+}
+#endif
+
+/**
+ * aperture_remove_all_conflicting_devices - remove all existing framebuffers
+ * @name: a descriptive name of the requesting driver
+ *
+ * This function removes all graphics device drivers. Use this function on systems
+ * that can have their framebuffer located anywhere in memory.
+ *
+ * Returns:
+ * 0 on success, or a negative errno code otherwise
+ */
+static inline int aperture_remove_all_conflicting_devices(const char *name)
+{
+	return aperture_remove_conflicting_devices(0, (resource_size_t)-1, name);
+}
+
+#endif

--- a/sys/compat/linuxkpi/common/include/linux/apple-gmux.h
+++ b/sys/compat/linuxkpi/common/include/linux/apple-gmux.h
@@ -1,0 +1,12 @@
+/* Public domain. */
+
+#ifndef _LINUXKPI_LINUX_APPLE_GMUX_H
+#define _LINUXKPI_LINUX_APPLE_GMUX_H
+
+static inline bool
+apple_gmux_detect(void *a, void *b)
+{
+	return false;
+}
+
+#endif

--- a/sys/compat/linuxkpi/common/include/linux/bitmap.h
+++ b/sys/compat/linuxkpi/common/include/linux/bitmap.h
@@ -349,4 +349,25 @@ bitmap_free(const unsigned long *bitmap)
 	kfree(bitmap);
 }
 
+
+static inline void
+bitmap_to_arr32(uint32_t *dst, const unsigned long *src, unsigned int size)
+{
+	const unsigned int end = howmany(size, 32);
+
+#ifdef __LP64__
+	unsigned int i = 0;
+	while (i < end) {
+		dst[i++] = (uint32_t)(*src & UINT_MAX);
+		if (i < end)
+			dst[i++] = (uint32_t)(*src >> 32);
+		src++;
+	}
+#else
+	bitmap_copy((unsigned long *)dst, src, size);
+#endif
+	if ((size % 32) != 0)
+		dst[end - 1] &= (uint32_t)(UINT_MAX >> (32 - (size % 32)));
+}
+
 #endif					/* _LINUXKPI_LINUX_BITMAP_H_ */

--- a/sys/compat/linuxkpi/common/include/linux/build_bug.h
+++ b/sys/compat/linuxkpi/common/include/linux/build_bug.h
@@ -1,0 +1,65 @@
+/*-
+ * Copyright (c) 2017 Mark Johnston <markj@FreeBSD.org>
+ * Copyright (c) 2018 Johannes Lundberg <johalun0@gmail.com>
+ * Copyright (c) 2021 The FreeBSD Foundation
+ * Copyright (c) 2021 Vladimir Kondratyev <wulf@FreeBSD.org>
+ * Copyright (c) 2023 Serenity Cyber Security, LLC
+ *
+ * Portions of this software were developed by Bjoern A. Zeeb
+ * under sponsorship from the FreeBSD Foundation.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice unmodified, this list of conditions, and the following
+ *    disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef	_LINUXKPI_LINUX_BUILD_BUG_H_
+#define	_LINUXKPI_LINUX_BUILD_BUG_H_
+
+#include <sys/param.h>
+
+#include <linux/compiler.h>
+
+/*
+ * BUILD_BUG_ON() can happen inside functions where _Static_assert() does not
+ * seem to work.  Use old-schoold-ish CTASSERT from before commit
+ * a3085588a88fa58eb5b1eaae471999e1995a29cf but also make sure we do not
+ * end up with an unused typedef or variable. The compiler should optimise
+ * it away entirely.
+ */
+#define	_O_CTASSERT(x)		_O__CTASSERT(x, __LINE__)
+#define	_O__CTASSERT(x, y)	_O___CTASSERT(x, y)
+#define	_O___CTASSERT(x, y)	while (0) { \
+    typedef char __assert_line_ ## y[(x) ? 1 : -1]; \
+    __assert_line_ ## y _x __unused; \
+    _x[0] = '\0'; \
+}
+
+#define	BUILD_BUG()			do { CTASSERT(0); } while (0)
+#define	BUILD_BUG_ON(x)			do { _O_CTASSERT(!(x)) } while (0)
+#define	BUILD_BUG_ON_MSG(x, msg)	BUILD_BUG_ON(x)
+#define	BUILD_BUG_ON_NOT_POWER_OF_2(x)	BUILD_BUG_ON(!powerof2(x))
+#define	BUILD_BUG_ON_INVALID(expr)	while (0) { (void)(expr); }
+#define	BUILD_BUG_ON_ZERO(x)	((int)sizeof(struct { int:-((x) != 0); }))
+
+#define static_assert(x, ...)		__static_assert(x, ##__VA_ARGS__, #x)
+#define __static_assert(x, msg, ...)	_Static_assert(x, msg)
+
+#endif

--- a/sys/compat/linuxkpi/common/include/linux/cleanup.h
+++ b/sys/compat/linuxkpi/common/include/linux/cleanup.h
@@ -1,0 +1,93 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2024-2025 The FreeBSD Foundation
+ *
+ * This software was developed by Björn Zeeb under sponsorship from
+ * the FreeBSD Foundation.
+ */
+
+#ifndef	_LINUXKPI_LINUX_CLEANUP_H
+#define	_LINUXKPI_LINUX_CLEANUP_H
+
+#define	__cleanup(_f)		__attribute__((__cleanup__(_f)))
+
+/*
+ * Note: "_T" are special as they are exposed into common code for
+ * statements.  Extra care should be taken when changing the code.
+ */
+#define	DEFINE_GUARD(_n, _dt, _lock, _unlock)				\
+									\
+    typedef _dt guard_ ## _n ## _t;					\
+									\
+    static inline _dt							\
+    guard_ ## _n ## _create( _dt _T)					\
+    {									\
+	_dt c;								\
+									\
+	c = ({ _lock; _T; });						\
+	return (c);							\
+    }									\
+									\
+    static inline void							\
+    guard_ ## _n ## _destroy(_dt *t)					\
+    {									\
+	_dt _T;								\
+									\
+	_T = *t;							\
+	if (_T) { _unlock; };						\
+    }
+
+/* We need to keep these calls unique. */
+#define	guard(_n)							\
+    guard_ ## _n ## _t guard_ ## _n ## _ ## __COUNTER__			\
+	__cleanup(guard_ ## _n ## _destroy) = guard_ ## _n ## _create
+
+#define	DEFINE_FREE(_n, _t, _f)						\
+    static inline void							\
+    __free_ ## _n(void *p)						\
+    {									\
+	_t _T;								\
+									\
+	_T = *(_t *)p;							\
+	_f;								\
+    }
+
+#define	__free(_n)		__cleanup(__free_##_n)
+
+/*
+ * Given this is a _0 version it should likely be broken up into parts.
+ * But we have no idead what a _1, _2, ... version would do different
+ * until we see a call.
+ * This is used for a not-real-type (rcu).   We use a bool to "simulate"
+ * the lock held.  Also _T still special, may not always be used, so tag
+ * with __unused (or better the LinuxKPI __maybe_unused).
+ */
+#define	DEFINE_LOCK_GUARD_0(_n, _lock, _unlock, ...)			\
+									\
+    typedef struct {							\
+	bool lock;							\
+	__VA_ARGS__;							\
+    } guard_ ## _n ## _t;	    					\
+									\
+    static inline void							\
+    guard_ ## _n ## _destroy(guard_ ## _n ## _t *_T)			\
+    {									\
+	if (_T->lock) {							\
+	    _unlock;							\
+	}								\
+    }									\
+									\
+    static inline guard_ ## _n ## _t					\
+    guard_ ## _n ## _create(void)					\
+    {									\
+	guard_ ## _n ## _t _tmp;					\
+	guard_ ## _n ## _t *_T __maybe_unused;				\
+									\
+	_tmp.lock = true;						\
+	_T = &_tmp;							\
+	_lock;								\
+	return (_tmp);							\
+    }
+
+#endif	/* _LINUXKPI_LINUX_CLEANUP_H */

--- a/sys/compat/linuxkpi/common/include/linux/compiler.h
+++ b/sys/compat/linuxkpi/common/include/linux/compiler.h
@@ -64,6 +64,7 @@
 #undef __always_inline
 #define	__always_inline			inline
 #define	noinline			__noinline
+#define	noinline_for_stack		__noinline
 #define	____cacheline_aligned		__aligned(CACHE_LINE_SIZE)
 #define	____cacheline_aligned_in_smp	__aligned(CACHE_LINE_SIZE)
 #define	fallthrough			/* FALLTHROUGH */ do { } while(0)

--- a/sys/compat/linuxkpi/common/include/linux/container_of.h
+++ b/sys/compat/linuxkpi/common/include/linux/container_of.h
@@ -1,0 +1,54 @@
+/*-
+ * Copyright (c) 2010 Isilon Systems, Inc.
+ * Copyright (c) 2010 iX Systems, Inc.
+ * Copyright (c) 2010 Panasas, Inc.
+ * Copyright (c) 2017 Matt Macy <mmacy@FreeBSD.org>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice unmodified, this list of conditions, and the following
+ *    disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _LINUXKPI_LINUX_CONTAINER_OF_H
+#define	_LINUXKPI_LINUX_CONTAINER_OF_H
+
+#include <sys/stdint.h>
+
+#include <linux/build_bug.h>
+#include <linux/stddef.h>
+
+#define	container_of(ptr, type, member)				\
+({								\
+	const __typeof(((type *)0)->member) *__p = (ptr);	\
+	(type *)((uintptr_t)__p - offsetof(type, member));	\
+})
+
+#define	container_of_const(ptr, type, member)			\
+    _Generic(ptr,						\
+	const typeof(*(ptr)) *:					\
+	    (const type *)container_of(ptr, type, member),	\
+	default:						\
+	    container_of(ptr, type, member)			\
+    )
+
+#define	typeof_member(type, member)	__typeof(((type *)0)->member)
+
+#endif

--- a/sys/compat/linuxkpi/common/include/linux/device.h
+++ b/sys/compat/linuxkpi/common/include/linux/device.h
@@ -659,4 +659,11 @@ devm_kmemdup(struct device *dev, const void *src, size_t len, gfp_t gfp)
 #define	devm_kcalloc(_dev, _sizen, _size, _gfp)			\
     devm_kmalloc((_dev), ((_sizen) * (_size)), (_gfp) | __GFP_ZERO)
 
+int lkpi_devm_add_action(struct device *dev, void (*action)(void *), void *data);
+#define	devm_add_action(dev, action, data)	\
+	lkpi_devm_add_action(dev, action, data)
+int lkpi_devm_add_action_or_reset(struct device *dev, void (*action)(void *), void *data);
+#define	devm_add_action_or_reset(dev, action, data)	\
+	lkpi_devm_add_action_or_reset(dev, action, data)
+
 #endif	/* _LINUXKPI_LINUX_DEVICE_H_ */

--- a/sys/compat/linuxkpi/common/include/linux/device.h
+++ b/sys/compat/linuxkpi/common/include/linux/device.h
@@ -126,6 +126,8 @@ struct device {
 
 	spinlock_t	devres_lock;
 	struct list_head devres_head;
+
+	struct dev_pm_info power;
 };
 
 extern struct device linux_root_device;

--- a/sys/compat/linuxkpi/common/include/linux/device/driver.h
+++ b/sys/compat/linuxkpi/common/include/linux/device/driver.h
@@ -1,0 +1,33 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2021 Bjoern A. Zeeb
+ * Copyright (c) 2024 The FreeBSD Foundation
+ *
+ * Portions of this software were developed by Björn Zeeb
+ * under sponsorship from the FreeBSD Foundation.
+ */
+
+#ifndef	LINUXKPI_LINUX_DEVICE_DRIVER_H
+#define	LINUXKPI_LINUX_DEVICE_DRIVER_H
+
+#include <sys/cdefs.h>
+#include <linux/module.h>
+
+#define	module_driver(_drv, _regf, _unregf)					\
+static inline int								\
+__CONCAT(__CONCAT(_, _drv), _init)(void)					\
+{										\
+	return (_regf(&(_drv)));		 				\
+}										\
+										\
+static inline void								\
+__CONCAT(__CONCAT(_, _drv), _exit)(void)					\
+{										\
+	_unregf(&(_drv));							\
+}										\
+										\
+module_init(__CONCAT(__CONCAT(_, _drv), _init));				\
+module_exit(__CONCAT(__CONCAT(_, _drv), _exit))
+
+#endif	/* LINUXKPI_LINUX_DEVICE_DRIVER_H */

--- a/sys/compat/linuxkpi/common/include/linux/dmi.h
+++ b/sys/compat/linuxkpi/common/include/linux/dmi.h
@@ -30,6 +30,7 @@
 #define	__LINUXKPI_LINUX_DMI_H__
 
 #include <sys/types.h>
+#include <linux/errno.h>
 #include <linux/mod_devicetable.h>
 
 struct dmi_header {

--- a/sys/compat/linuxkpi/common/include/linux/dynamic_debug.h
+++ b/sys/compat/linuxkpi/common/include/linux/dynamic_debug.h
@@ -1,0 +1,8 @@
+/* Public domain. */
+
+#ifndef _LINUXKPI_LINUX_DYNAMIC_DEBUG_H
+#define _LINUXKPI_LINUX_DYNAMIC_DEBUG_H
+
+#define DECLARE_DYNDBG_CLASSMAP(a, b, c, ...)
+
+#endif

--- a/sys/compat/linuxkpi/common/include/linux/fips.h
+++ b/sys/compat/linuxkpi/common/include/linux/fips.h
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2025 Bjoern A. Zeeb
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#ifndef	_LINUXKPI_LINUX_FIPS_H
+#define	_LINUXKPI_LINUX_FIPS_H
+
+#define	fips_enabled	0
+
+#endif /* _LINUXKPI_LINUX_FIPS_H */

--- a/sys/compat/linuxkpi/common/include/linux/gpf.h
+++ b/sys/compat/linuxkpi/common/include/linux/gpf.h
@@ -1,0 +1,33 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2024 Serenity Cyber Security, LLC.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#ifndef _LINUXKPI_LINUX_GPF_H_
+#define	_LINUXKPI_LINUX_GPF_H_
+
+#include <linux/mmzone.h>
+
+#endif /* _LINUXKPI_LINUX_GPF_H_ */

--- a/sys/compat/linuxkpi/common/include/linux/hdmi.h
+++ b/sys/compat/linuxkpi/common/include/linux/hdmi.h
@@ -1,0 +1,447 @@
+/*
+ * Copyright (C) 2012 Avionic Design GmbH
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sub license,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the
+ * next paragraph) shall be included in all copies or substantial portions
+ * of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef __LINUX_HDMI_H_
+#define __LINUX_HDMI_H_
+
+#include <linux/types.h>
+#include <linux/device.h>
+
+enum hdmi_packet_type {
+	HDMI_PACKET_TYPE_NULL = 0x00,
+	HDMI_PACKET_TYPE_AUDIO_CLOCK_REGEN = 0x01,
+	HDMI_PACKET_TYPE_AUDIO_SAMPLE = 0x02,
+	HDMI_PACKET_TYPE_GENERAL_CONTROL = 0x03,
+	HDMI_PACKET_TYPE_ACP = 0x04,
+	HDMI_PACKET_TYPE_ISRC1 = 0x05,
+	HDMI_PACKET_TYPE_ISRC2 = 0x06,
+	HDMI_PACKET_TYPE_ONE_BIT_AUDIO_SAMPLE = 0x07,
+	HDMI_PACKET_TYPE_DST_AUDIO = 0x08,
+	HDMI_PACKET_TYPE_HBR_AUDIO_STREAM = 0x09,
+	HDMI_PACKET_TYPE_GAMUT_METADATA = 0x0a,
+	/* + enum hdmi_infoframe_type */
+};
+
+enum hdmi_infoframe_type {
+	HDMI_INFOFRAME_TYPE_VENDOR = 0x81,
+	HDMI_INFOFRAME_TYPE_AVI = 0x82,
+	HDMI_INFOFRAME_TYPE_SPD = 0x83,
+	HDMI_INFOFRAME_TYPE_AUDIO = 0x84,
+	HDMI_INFOFRAME_TYPE_DRM = 0x87,
+};
+
+#define HDMI_IEEE_OUI 0x000c03
+#define HDMI_FORUM_IEEE_OUI 0xc45dd8
+#define HDMI_INFOFRAME_HEADER_SIZE  4
+#define HDMI_AVI_INFOFRAME_SIZE    13
+#define HDMI_SPD_INFOFRAME_SIZE    25
+#define HDMI_AUDIO_INFOFRAME_SIZE  10
+#define HDMI_DRM_INFOFRAME_SIZE    26
+#define HDMI_VENDOR_INFOFRAME_SIZE  4
+
+#define HDMI_INFOFRAME_SIZE(type)	\
+	(HDMI_INFOFRAME_HEADER_SIZE + HDMI_ ## type ## _INFOFRAME_SIZE)
+
+struct hdmi_any_infoframe {
+	enum hdmi_infoframe_type type;
+	unsigned char version;
+	unsigned char length;
+};
+
+enum hdmi_colorspace {
+	HDMI_COLORSPACE_RGB,
+	HDMI_COLORSPACE_YUV422,
+	HDMI_COLORSPACE_YUV444,
+	HDMI_COLORSPACE_YUV420,
+	HDMI_COLORSPACE_RESERVED4,
+	HDMI_COLORSPACE_RESERVED5,
+	HDMI_COLORSPACE_RESERVED6,
+	HDMI_COLORSPACE_IDO_DEFINED,
+};
+
+enum hdmi_scan_mode {
+	HDMI_SCAN_MODE_NONE,
+	HDMI_SCAN_MODE_OVERSCAN,
+	HDMI_SCAN_MODE_UNDERSCAN,
+	HDMI_SCAN_MODE_RESERVED,
+};
+
+enum hdmi_colorimetry {
+	HDMI_COLORIMETRY_NONE,
+	HDMI_COLORIMETRY_ITU_601,
+	HDMI_COLORIMETRY_ITU_709,
+	HDMI_COLORIMETRY_EXTENDED,
+};
+
+enum hdmi_picture_aspect {
+	HDMI_PICTURE_ASPECT_NONE,
+	HDMI_PICTURE_ASPECT_4_3,
+	HDMI_PICTURE_ASPECT_16_9,
+	HDMI_PICTURE_ASPECT_64_27,
+	HDMI_PICTURE_ASPECT_256_135,
+	HDMI_PICTURE_ASPECT_RESERVED,
+};
+
+enum hdmi_active_aspect {
+	HDMI_ACTIVE_ASPECT_16_9_TOP = 2,
+	HDMI_ACTIVE_ASPECT_14_9_TOP = 3,
+	HDMI_ACTIVE_ASPECT_16_9_CENTER = 4,
+	HDMI_ACTIVE_ASPECT_PICTURE = 8,
+	HDMI_ACTIVE_ASPECT_4_3 = 9,
+	HDMI_ACTIVE_ASPECT_16_9 = 10,
+	HDMI_ACTIVE_ASPECT_14_9 = 11,
+	HDMI_ACTIVE_ASPECT_4_3_SP_14_9 = 13,
+	HDMI_ACTIVE_ASPECT_16_9_SP_14_9 = 14,
+	HDMI_ACTIVE_ASPECT_16_9_SP_4_3 = 15,
+};
+
+enum hdmi_extended_colorimetry {
+	HDMI_EXTENDED_COLORIMETRY_XV_YCC_601,
+	HDMI_EXTENDED_COLORIMETRY_XV_YCC_709,
+	HDMI_EXTENDED_COLORIMETRY_S_YCC_601,
+	HDMI_EXTENDED_COLORIMETRY_OPYCC_601,
+	HDMI_EXTENDED_COLORIMETRY_OPRGB,
+
+	/* The following EC values are only defined in CEA-861-F. */
+	HDMI_EXTENDED_COLORIMETRY_BT2020_CONST_LUM,
+	HDMI_EXTENDED_COLORIMETRY_BT2020,
+	HDMI_EXTENDED_COLORIMETRY_RESERVED,
+};
+
+enum hdmi_quantization_range {
+	HDMI_QUANTIZATION_RANGE_DEFAULT,
+	HDMI_QUANTIZATION_RANGE_LIMITED,
+	HDMI_QUANTIZATION_RANGE_FULL,
+	HDMI_QUANTIZATION_RANGE_RESERVED,
+};
+
+/* non-uniform picture scaling */
+enum hdmi_nups {
+	HDMI_NUPS_UNKNOWN,
+	HDMI_NUPS_HORIZONTAL,
+	HDMI_NUPS_VERTICAL,
+	HDMI_NUPS_BOTH,
+};
+
+enum hdmi_ycc_quantization_range {
+	HDMI_YCC_QUANTIZATION_RANGE_LIMITED,
+	HDMI_YCC_QUANTIZATION_RANGE_FULL,
+};
+
+enum hdmi_content_type {
+	HDMI_CONTENT_TYPE_GRAPHICS,
+	HDMI_CONTENT_TYPE_PHOTO,
+	HDMI_CONTENT_TYPE_CINEMA,
+	HDMI_CONTENT_TYPE_GAME,
+};
+
+enum hdmi_metadata_type {
+	HDMI_STATIC_METADATA_TYPE1 = 0,
+};
+
+enum hdmi_eotf {
+	HDMI_EOTF_TRADITIONAL_GAMMA_SDR,
+	HDMI_EOTF_TRADITIONAL_GAMMA_HDR,
+	HDMI_EOTF_SMPTE_ST2084,
+	HDMI_EOTF_BT_2100_HLG,
+};
+
+struct hdmi_avi_infoframe {
+	enum hdmi_infoframe_type type;
+	unsigned char version;
+	unsigned char length;
+	enum hdmi_colorspace colorspace;
+	enum hdmi_scan_mode scan_mode;
+	enum hdmi_colorimetry colorimetry;
+	enum hdmi_picture_aspect picture_aspect;
+	enum hdmi_active_aspect active_aspect;
+	bool itc;
+	enum hdmi_extended_colorimetry extended_colorimetry;
+	enum hdmi_quantization_range quantization_range;
+	enum hdmi_nups nups;
+	unsigned char video_code;
+	enum hdmi_ycc_quantization_range ycc_quantization_range;
+	enum hdmi_content_type content_type;
+	unsigned char pixel_repeat;
+	unsigned short top_bar;
+	unsigned short bottom_bar;
+	unsigned short left_bar;
+	unsigned short right_bar;
+};
+
+/* DRM Infoframe as per CTA 861.G spec */
+struct hdmi_drm_infoframe {
+	enum hdmi_infoframe_type type;
+	unsigned char version;
+	unsigned char length;
+	enum hdmi_eotf eotf;
+	enum hdmi_metadata_type metadata_type;
+	struct {
+		u16 x, y;
+	} display_primaries[3];
+	struct {
+		u16 x, y;
+	} white_point;
+	u16 max_display_mastering_luminance;
+	u16 min_display_mastering_luminance;
+	u16 max_cll;
+	u16 max_fall;
+};
+
+void hdmi_avi_infoframe_init(struct hdmi_avi_infoframe *frame);
+ssize_t hdmi_avi_infoframe_pack(struct hdmi_avi_infoframe *frame, void *buffer,
+				size_t size);
+ssize_t hdmi_avi_infoframe_pack_only(const struct hdmi_avi_infoframe *frame,
+				     void *buffer, size_t size);
+int hdmi_avi_infoframe_check(struct hdmi_avi_infoframe *frame);
+int hdmi_drm_infoframe_init(struct hdmi_drm_infoframe *frame);
+ssize_t hdmi_drm_infoframe_pack(struct hdmi_drm_infoframe *frame, void *buffer,
+				size_t size);
+ssize_t hdmi_drm_infoframe_pack_only(const struct hdmi_drm_infoframe *frame,
+				     void *buffer, size_t size);
+int hdmi_drm_infoframe_check(struct hdmi_drm_infoframe *frame);
+int hdmi_drm_infoframe_unpack_only(struct hdmi_drm_infoframe *frame,
+				   const void *buffer, size_t size);
+
+enum hdmi_spd_sdi {
+	HDMI_SPD_SDI_UNKNOWN,
+	HDMI_SPD_SDI_DSTB,
+	HDMI_SPD_SDI_DVDP,
+	HDMI_SPD_SDI_DVHS,
+	HDMI_SPD_SDI_HDDVR,
+	HDMI_SPD_SDI_DVC,
+	HDMI_SPD_SDI_DSC,
+	HDMI_SPD_SDI_VCD,
+	HDMI_SPD_SDI_GAME,
+	HDMI_SPD_SDI_PC,
+	HDMI_SPD_SDI_BD,
+	HDMI_SPD_SDI_SACD,
+	HDMI_SPD_SDI_HDDVD,
+	HDMI_SPD_SDI_PMP,
+};
+
+struct hdmi_spd_infoframe {
+	enum hdmi_infoframe_type type;
+	unsigned char version;
+	unsigned char length;
+	char vendor[8];
+	char product[16];
+	enum hdmi_spd_sdi sdi;
+};
+
+int hdmi_spd_infoframe_init(struct hdmi_spd_infoframe *frame,
+			    const char *vendor, const char *product);
+ssize_t hdmi_spd_infoframe_pack(struct hdmi_spd_infoframe *frame, void *buffer,
+				size_t size);
+ssize_t hdmi_spd_infoframe_pack_only(const struct hdmi_spd_infoframe *frame,
+				     void *buffer, size_t size);
+int hdmi_spd_infoframe_check(struct hdmi_spd_infoframe *frame);
+
+enum hdmi_audio_coding_type {
+	HDMI_AUDIO_CODING_TYPE_STREAM,
+	HDMI_AUDIO_CODING_TYPE_PCM,
+	HDMI_AUDIO_CODING_TYPE_AC3,
+	HDMI_AUDIO_CODING_TYPE_MPEG1,
+	HDMI_AUDIO_CODING_TYPE_MP3,
+	HDMI_AUDIO_CODING_TYPE_MPEG2,
+	HDMI_AUDIO_CODING_TYPE_AAC_LC,
+	HDMI_AUDIO_CODING_TYPE_DTS,
+	HDMI_AUDIO_CODING_TYPE_ATRAC,
+	HDMI_AUDIO_CODING_TYPE_DSD,
+	HDMI_AUDIO_CODING_TYPE_EAC3,
+	HDMI_AUDIO_CODING_TYPE_DTS_HD,
+	HDMI_AUDIO_CODING_TYPE_MLP,
+	HDMI_AUDIO_CODING_TYPE_DST,
+	HDMI_AUDIO_CODING_TYPE_WMA_PRO,
+	HDMI_AUDIO_CODING_TYPE_CXT,
+};
+
+enum hdmi_audio_sample_size {
+	HDMI_AUDIO_SAMPLE_SIZE_STREAM,
+	HDMI_AUDIO_SAMPLE_SIZE_16,
+	HDMI_AUDIO_SAMPLE_SIZE_20,
+	HDMI_AUDIO_SAMPLE_SIZE_24,
+};
+
+enum hdmi_audio_sample_frequency {
+	HDMI_AUDIO_SAMPLE_FREQUENCY_STREAM,
+	HDMI_AUDIO_SAMPLE_FREQUENCY_32000,
+	HDMI_AUDIO_SAMPLE_FREQUENCY_44100,
+	HDMI_AUDIO_SAMPLE_FREQUENCY_48000,
+	HDMI_AUDIO_SAMPLE_FREQUENCY_88200,
+	HDMI_AUDIO_SAMPLE_FREQUENCY_96000,
+	HDMI_AUDIO_SAMPLE_FREQUENCY_176400,
+	HDMI_AUDIO_SAMPLE_FREQUENCY_192000,
+};
+
+enum hdmi_audio_coding_type_ext {
+	/* Refer to Audio Coding Type (CT) field in Data Byte 1 */
+	HDMI_AUDIO_CODING_TYPE_EXT_CT,
+
+	/*
+	 * The next three CXT values are defined in CEA-861-E only.
+	 * They do not exist in older versions, and in CEA-861-F they are
+	 * defined as 'Not in use'.
+	 */
+	HDMI_AUDIO_CODING_TYPE_EXT_HE_AAC,
+	HDMI_AUDIO_CODING_TYPE_EXT_HE_AAC_V2,
+	HDMI_AUDIO_CODING_TYPE_EXT_MPEG_SURROUND,
+
+	/* The following CXT values are only defined in CEA-861-F. */
+	HDMI_AUDIO_CODING_TYPE_EXT_MPEG4_HE_AAC,
+	HDMI_AUDIO_CODING_TYPE_EXT_MPEG4_HE_AAC_V2,
+	HDMI_AUDIO_CODING_TYPE_EXT_MPEG4_AAC_LC,
+	HDMI_AUDIO_CODING_TYPE_EXT_DRA,
+	HDMI_AUDIO_CODING_TYPE_EXT_MPEG4_HE_AAC_SURROUND,
+	HDMI_AUDIO_CODING_TYPE_EXT_MPEG4_AAC_LC_SURROUND = 10,
+};
+
+struct hdmi_audio_infoframe {
+	enum hdmi_infoframe_type type;
+	unsigned char version;
+	unsigned char length;
+	unsigned char channels;
+	enum hdmi_audio_coding_type coding_type;
+	enum hdmi_audio_sample_size sample_size;
+	enum hdmi_audio_sample_frequency sample_frequency;
+	enum hdmi_audio_coding_type_ext coding_type_ext;
+	unsigned char channel_allocation;
+	unsigned char level_shift_value;
+	bool downmix_inhibit;
+
+};
+
+int hdmi_audio_infoframe_init(struct hdmi_audio_infoframe *frame);
+ssize_t hdmi_audio_infoframe_pack(struct hdmi_audio_infoframe *frame,
+				  void *buffer, size_t size);
+ssize_t hdmi_audio_infoframe_pack_only(const struct hdmi_audio_infoframe *frame,
+				       void *buffer, size_t size);
+int hdmi_audio_infoframe_check(const struct hdmi_audio_infoframe *frame);
+
+#ifdef __linux__
+struct dp_sdp;
+ssize_t
+hdmi_audio_infoframe_pack_for_dp(const struct hdmi_audio_infoframe *frame,
+				 struct dp_sdp *sdp, u8 dp_version);
+#endif
+
+enum hdmi_3d_structure {
+	HDMI_3D_STRUCTURE_INVALID = -1,
+	HDMI_3D_STRUCTURE_FRAME_PACKING = 0,
+	HDMI_3D_STRUCTURE_FIELD_ALTERNATIVE,
+	HDMI_3D_STRUCTURE_LINE_ALTERNATIVE,
+	HDMI_3D_STRUCTURE_SIDE_BY_SIDE_FULL,
+	HDMI_3D_STRUCTURE_L_DEPTH,
+	HDMI_3D_STRUCTURE_L_DEPTH_GFX_GFX_DEPTH,
+	HDMI_3D_STRUCTURE_TOP_AND_BOTTOM,
+	HDMI_3D_STRUCTURE_SIDE_BY_SIDE_HALF = 8,
+};
+
+
+struct hdmi_vendor_infoframe {
+	enum hdmi_infoframe_type type;
+	unsigned char version;
+	unsigned char length;
+	unsigned int oui;
+	u8 vic;
+	enum hdmi_3d_structure s3d_struct;
+	unsigned int s3d_ext_data;
+};
+
+/* HDR Metadata as per 861.G spec */
+struct hdr_static_metadata {
+	__u8 eotf;
+	__u8 metadata_type;
+	__u16 max_cll;
+	__u16 max_fall;
+	__u16 min_cll;
+};
+
+/**
+ * struct hdr_sink_metadata - HDR sink metadata
+ *
+ * Metadata Information read from Sink's EDID
+ */
+struct hdr_sink_metadata {
+	/**
+	 * @metadata_type: Static_Metadata_Descriptor_ID.
+	 */
+	__u32 metadata_type;
+	/**
+	 * @hdmi_type1: HDR Metadata Infoframe.
+	 */
+	union {
+		struct hdr_static_metadata hdmi_type1;
+	};
+};
+
+int hdmi_vendor_infoframe_init(struct hdmi_vendor_infoframe *frame);
+ssize_t hdmi_vendor_infoframe_pack(struct hdmi_vendor_infoframe *frame,
+				   void *buffer, size_t size);
+ssize_t hdmi_vendor_infoframe_pack_only(const struct hdmi_vendor_infoframe *frame,
+					void *buffer, size_t size);
+int hdmi_vendor_infoframe_check(struct hdmi_vendor_infoframe *frame);
+
+union hdmi_vendor_any_infoframe {
+	struct {
+		enum hdmi_infoframe_type type;
+		unsigned char version;
+		unsigned char length;
+		unsigned int oui;
+	} any;
+	struct hdmi_vendor_infoframe hdmi;
+};
+
+/**
+ * union hdmi_infoframe - overall union of all abstract infoframe representations
+ * @any: generic infoframe
+ * @avi: avi infoframe
+ * @spd: spd infoframe
+ * @vendor: union of all vendor infoframes
+ * @audio: audio infoframe
+ * @drm: Dynamic Range and Mastering infoframe
+ *
+ * This is used by the generic pack function. This works since all infoframes
+ * have the same header which also indicates which type of infoframe should be
+ * packed.
+ */
+union hdmi_infoframe {
+	struct hdmi_any_infoframe any;
+	struct hdmi_avi_infoframe avi;
+	struct hdmi_spd_infoframe spd;
+	union hdmi_vendor_any_infoframe vendor;
+	struct hdmi_audio_infoframe audio;
+	struct hdmi_drm_infoframe drm;
+};
+
+ssize_t hdmi_infoframe_pack(union hdmi_infoframe *frame, void *buffer,
+			    size_t size);
+ssize_t hdmi_infoframe_pack_only(const union hdmi_infoframe *frame,
+				 void *buffer, size_t size);
+int hdmi_infoframe_check(union hdmi_infoframe *frame);
+int hdmi_infoframe_unpack(union hdmi_infoframe *frame,
+			  const void *buffer, size_t size);
+void hdmi_infoframe_log(const char *level, struct device *dev,
+			const union hdmi_infoframe *frame);
+
+#endif /* _DRM_HDMI_H */

--- a/sys/compat/linuxkpi/common/include/linux/interrupt.h
+++ b/sys/compat/linuxkpi/common/include/linux/interrupt.h
@@ -160,7 +160,9 @@ irq_set_status_flags(unsigned int irq __unused, unsigned long flags __unused)
 /*
  * LinuxKPI tasklet support
  */
+struct tasklet_struct;
 typedef void tasklet_func_t(unsigned long);
+typedef void tasklet_callback_t(struct tasklet_struct *);
 
 struct tasklet_struct {
 	TAILQ_ENTRY(tasklet_struct) entry;
@@ -169,12 +171,20 @@ struct tasklet_struct {
 	volatile u_int tasklet_state;
 	atomic_t count;
 	unsigned long data;
+	tasklet_callback_t *callback;
+	bool use_callback;
 };
 
 #define	DECLARE_TASKLET(_name, _func, _data)	\
 struct tasklet_struct _name = { .func = (_func), .data = (_data) }
 
 #define	tasklet_hi_schedule(t)	tasklet_schedule(t)
+
+/* Some other compat code in the tree has this defined as well. */
+#define	from_tasklet(_dev, _t, _field)		\
+    container_of(_t, typeof(*(_dev)), _field)
+
+void tasklet_setup(struct tasklet_struct *, tasklet_callback_t *);
 
 extern void tasklet_schedule(struct tasklet_struct *);
 extern void tasklet_kill(struct tasklet_struct *);

--- a/sys/compat/linuxkpi/common/include/linux/io-64-nonatomic-lo-hi.h
+++ b/sys/compat/linuxkpi/common/include/linux/io-64-nonatomic-lo-hi.h
@@ -1,0 +1,65 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2022 Felix Palmen
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+#ifndef	_LINUXKPI_LINUX_IO_64_NONATOMIC_LO_HI_H_
+#define	_LINUXKPI_LINUX_IO_64_NONATOMIC_LO_HI_H_
+
+#include <linux/io.h>
+
+static inline uint64_t
+lo_hi_readq(const volatile void *addr)
+{
+	const volatile uint32_t *p = addr;
+	uint32_t l, h;
+
+	__io_br();
+	l = le32toh(__raw_readl(p));
+	h = le32toh(__raw_readl(p + 1));
+	__io_ar();
+
+	return (l + ((uint64_t)h << 32));
+}
+
+static inline void
+lo_hi_writeq(uint64_t v, volatile void *addr)
+{
+	volatile uint32_t *p = addr;
+
+	__io_bw();
+	__raw_writel(htole32(v), p);
+	__raw_writel(htole32(v >> 32), p + 1);
+	__io_aw();
+}
+
+#ifndef readq
+#define readq(addr)	lo_hi_readq(addr)
+#endif
+
+#ifndef writeq
+#define writeq(v, addr)	lo_hi_writeq(v, addr)
+#endif
+
+#endif	/* _LINUXKPI_LINUX_IO_64_NONATOMIC_LO_HI_H_ */

--- a/sys/compat/linuxkpi/common/include/linux/iommu.h
+++ b/sys/compat/linuxkpi/common/include/linux/iommu.h
@@ -1,0 +1,29 @@
+/* Public domain. */
+
+#ifndef _LINUXKPI_LINUX_IOMMU_H_
+#define	_LINUXKPI_LINUX_IOMMU_H_
+
+#include <linux/device.h>
+
+#define	__IOMMU_DOMAIN_PAGING	(1U << 0)
+#define	__IOMMU_DOMAIN_DMA_API	(1U << 1)
+#define	__IOMMU_DOMAIN_PT	(1U << 2)
+#define	__IOMMU_DOMAIN_DMA_FQ	(1U << 3)
+
+#define	IOMMU_DOMAIN_BLOCKED	(0U)
+#define	IOMMU_DOMAIN_IDENTITY	(__IOMMU_DOMAIN_PT)
+#define	IOMMU_DOMAIN_UNMANAGED	(__IOMMU_DOMAIN_PAGING)
+#define	IOMMU_DOMAIN_DMA	(__IOMMU_DOMAIN_PAGING | __IOMMU_DOMAIN_DMA_API)
+#define	IOMMU_DOMAIN_DMA_FQ	(__IOMMU_DOMAIN_PAGING | __IOMMU_DOMAIN_DMA_API | __IOMMU_DOMAIN_DMA_FQ)
+
+struct iommu_domain {
+	unsigned int type;
+};
+
+static inline struct iommu_domain *
+iommu_get_domain_for_dev(struct device *dev __unused)
+{
+	return (NULL);
+}
+
+#endif /* _LINUXKPI_LINUX_IOMMU_H_ */

--- a/sys/compat/linuxkpi/common/include/linux/ioport.h
+++ b/sys/compat/linuxkpi/common/include/linux/ioport.h
@@ -1,0 +1,57 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2023 Serenity Cyber Security, LLC.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#ifndef _LINUXKPI_LINUX_IOPORT_H
+#define _LINUXKPI_LINUX_IOPORT_H
+
+#include <linux/compiler.h>
+#include <linux/types.h>
+
+#define DEFINE_RES_MEM(_start, _size)		\
+	(struct resource) {			\
+		.start = (_start),		\
+		.end = (_start) + (_size) - 1,	\
+	}
+
+struct resource {
+	resource_size_t start;
+	resource_size_t end;
+};
+
+static inline resource_size_t
+resource_size(const struct resource *r)
+{
+	return (r->end - r->start + 1);
+}
+
+static inline bool
+resource_contains(struct resource *a, struct resource *b)
+{
+	return (a->start <= b->start && a->end >= b->end);
+}
+
+#endif

--- a/sys/compat/linuxkpi/common/include/linux/iosys-map.h
+++ b/sys/compat/linuxkpi/common/include/linux/iosys-map.h
@@ -1,0 +1,161 @@
+/* Public domain. */
+
+#ifndef _LINUXKPI_LINUX_IOSYS_MAP_H
+#define _LINUXKPI_LINUX_IOSYS_MAP_H
+
+#include <linux/io.h>
+#include <linux/string.h>
+
+struct iosys_map {
+	union {
+		void *vaddr_iomem;
+		void *vaddr;
+	};
+	bool is_iomem;
+#ifdef __OpenBSD__
+	bus_space_handle_t bsh;
+	bus_size_t size;
+#endif
+};
+
+#define IOSYS_MAP_INIT_OFFSET(_ism_src_p, _off) ({			\
+	struct iosys_map ism_dst = *(_ism_src_p);			\
+	iosys_map_incr(&ism_dst, _off);					\
+	ism_dst;							\
+})
+
+static inline void
+iosys_map_incr(struct iosys_map *ism, size_t n)
+{
+	if (ism->is_iomem)
+		ism->vaddr_iomem += n;
+	else
+		ism->vaddr += n;
+}
+
+static inline void
+iosys_map_memcpy_to(struct iosys_map *ism, size_t off, const void *src,
+    size_t len)
+{
+	if (ism->is_iomem)
+		memcpy_toio(ism->vaddr_iomem + off, src, len);
+	else
+		memcpy(ism->vaddr + off, src, len);
+}
+
+static inline bool
+iosys_map_is_null(const struct iosys_map *ism)
+{
+	if (ism->is_iomem)
+		return (ism->vaddr_iomem == NULL);
+	else
+		return (ism->vaddr == NULL);
+}
+
+static inline bool
+iosys_map_is_set(const struct iosys_map *ism)
+{
+	if (ism->is_iomem)
+		return (ism->vaddr_iomem != NULL);
+	else
+		return (ism->vaddr != NULL);
+}
+
+static inline bool
+iosys_map_is_equal(const struct iosys_map *ism_a,
+    const struct iosys_map *ism_b)
+{
+	if (ism_a->is_iomem != ism_b->is_iomem)
+		return (false);
+
+	if (ism_a->is_iomem)
+		return (ism_a->vaddr_iomem == ism_b->vaddr_iomem);
+	else
+		return (ism_a->vaddr == ism_b->vaddr);
+}
+
+static inline void
+iosys_map_clear(struct iosys_map *ism)
+{
+	if (ism->is_iomem) {
+		ism->vaddr_iomem = NULL;
+		ism->is_iomem = false;
+	} else {
+		ism->vaddr = NULL;
+	}
+}
+
+static inline void
+iosys_map_set_vaddr_iomem(struct iosys_map *ism, void *addr)
+{
+	ism->vaddr_iomem = addr;
+	ism->is_iomem = true;
+}
+
+static inline void
+iosys_map_set_vaddr(struct iosys_map *ism, void *addr)
+{
+	ism->vaddr = addr;
+	ism->is_iomem = false;
+}
+
+static inline void
+iosys_map_memset(struct iosys_map *ism, size_t off, int value, size_t len)
+{
+	if (ism->is_iomem)
+		memset_io(ism->vaddr_iomem + off, value, len);
+	else
+		memset(ism->vaddr + off, value, len);
+}
+
+#ifdef __LP64__
+#define	_iosys_map_readq(_addr)			readq(_addr)
+#define	_iosys_map_writeq(_val, _addr)		writeq(_val, _addr)
+#else
+#define	_iosys_map_readq(_addr) ({					\
+	uint64_t val;							\
+	memcpy_fromio(&val, _addr, sizeof(uint64_t));			\
+	val;								\
+})
+#define	_iosys_map_writeq(_val, _addr)					\
+	memcpy_toio(_addr, &(_val), sizeof(uint64_t))
+#endif
+
+#define	iosys_map_rd(_ism, _off, _type) ({				\
+	_type val;							\
+	if ((_ism)->is_iomem) {						\
+		void *addr = (_ism)->vaddr_iomem + (_off);		\
+		val = _Generic(val,					\
+		    uint8_t : readb(addr),				\
+		    uint16_t: readw(addr),				\
+		    uint32_t: readl(addr),				\
+		    uint64_t: _iosys_map_readq(addr));			\
+	} else								\
+		val = READ_ONCE(*(_type *)((_ism)->vaddr + (_off)));	\
+	val;								\
+})
+#define	iosys_map_wr(_ism, _off, _type, _val) ({			\
+	_type val = (_val);						\
+	if ((_ism)->is_iomem) {						\
+		void *addr = (_ism)->vaddr_iomem + (_off);		\
+		_Generic(val,						\
+		    uint8_t : writeb(val, addr),			\
+		    uint16_t: writew(val, addr),			\
+		    uint32_t: writel(val, addr),			\
+		    uint64_t: _iosys_map_writeq(val, addr));		\
+	} else								\
+		WRITE_ONCE(*(_type *)((_ism)->vaddr + (_off)), val);	\
+})
+
+#define	iosys_map_rd_field(_ism, _off, _type, _field) ({		\
+	_type *s;							\
+	iosys_map_rd(_ism, (_off) + offsetof(_type, _field),		\
+	    __typeof(s->_field));					\
+})
+#define	iosys_map_wr_field(_ism, _off, _type, _field, _val) ({		\
+	_type *s;							\
+	iosys_map_wr(_ism, (_off) + offsetof(_type, _field),		\
+	    __typeof(s->_field), _val);					\
+})
+
+#endif

--- a/sys/compat/linuxkpi/common/include/linux/irqdomain.h
+++ b/sys/compat/linuxkpi/common/include/linux/irqdomain.h
@@ -1,0 +1,10 @@
+/* Public domain. */
+
+#ifndef _LINUXKPI_LINUX_IRQDOMAIN_H
+#define	_LINUXKPI_LINUX_IRQDOMAIN_H
+
+#include <linux/mutex.h>
+#include <linux/of.h>
+#include <linux/radix-tree.h>
+
+#endif

--- a/sys/compat/linuxkpi/common/include/linux/kernel.h
+++ b/sys/compat/linuxkpi/common/include/linux/kernel.h
@@ -51,6 +51,7 @@
 #include <linux/jiffies.h>
 #include <linux/log2.h>
 #include <linux/math64.h>
+#include <linux/build_bug.h>
 #include <linux/kconfig.h>
 
 #include <asm/byteorder.h>
@@ -92,27 +93,6 @@
 #define	S64_C(x) x ## LL
 #define	U64_C(x) x ## ULL
 
-/*
- * BUILD_BUG_ON() can happen inside functions where _Static_assert() does not
- * seem to work.  Use old-schoold-ish CTASSERT from before commit
- * a3085588a88fa58eb5b1eaae471999e1995a29cf but also make sure we do not
- * end up with an unused typedef or variable. The compiler should optimise
- * it away entirely.
- */
-#define	_O_CTASSERT(x)		_O__CTASSERT(x, __LINE__)
-#define	_O__CTASSERT(x, y)	_O___CTASSERT(x, y)
-#define	_O___CTASSERT(x, y)	while (0) { \
-    typedef char __assert_line_ ## y[(x) ? 1 : -1]; \
-    __assert_line_ ## y _x; \
-    _x[0] = '\0'; \
-}
-
-#define	BUILD_BUG()			do { CTASSERT(0); } while (0)
-#define	BUILD_BUG_ON(x)			do { _O_CTASSERT(!(x)) } while (0)
-#define	BUILD_BUG_ON_MSG(x, msg)	BUILD_BUG_ON(x)
-#define	BUILD_BUG_ON_NOT_POWER_OF_2(x)	BUILD_BUG_ON(!powerof2(x))
-#define	BUILD_BUG_ON_INVALID(expr)	while (0) { (void)(expr); }
-#define	BUILD_BUG_ON_ZERO(x)	((int)sizeof(struct { int:-((x) != 0); }))
 
 #define	BUG()			panic("BUG at %s:%d", __FILE__, __LINE__)
 #define	BUG_ON(cond)		do {				\

--- a/sys/compat/linuxkpi/common/include/linux/kernel.h
+++ b/sys/compat/linuxkpi/common/include/linux/kernel.h
@@ -52,6 +52,7 @@
 #include <linux/log2.h>
 #include <linux/math64.h>
 #include <linux/build_bug.h>
+#include <linux/limits.h>
 #include <linux/kconfig.h>
 
 #include <asm/byteorder.h>
@@ -71,18 +72,6 @@
 #define	KERN_INFO	"<6>"
 #define	KERN_DEBUG	"<7>"
 
-#define	U8_MAX		((u8)~0U)
-#define	S8_MAX		((s8)(U8_MAX >> 1))
-#define	S8_MIN		((s8)(-S8_MAX - 1))
-#define	U16_MAX		((u16)~0U)
-#define	S16_MAX		((s16)(U16_MAX >> 1))
-#define	S16_MIN		((s16)(-S16_MAX - 1))
-#define	U32_MAX		((u32)~0U)
-#define	S32_MAX		((s32)(U32_MAX >> 1))
-#define	S32_MIN		((s32)(-S32_MAX - 1))
-#define	U64_MAX		((u64)~0ULL)
-#define	S64_MAX		((s64)(U64_MAX >> 1))
-#define	S64_MIN		((s64)(-S64_MAX - 1))
 
 #define	S8_C(x)  x
 #define	U8_C(x)  x ## U

--- a/sys/compat/linuxkpi/common/include/linux/kernel.h
+++ b/sys/compat/linuxkpi/common/include/linux/kernel.h
@@ -50,6 +50,7 @@
 #include <linux/typecheck.h>
 #include <linux/jiffies.h>
 #include <linux/log2.h>
+#include <linux/math64.h>
 #include <linux/kconfig.h>
 
 #include <asm/byteorder.h>

--- a/sys/compat/linuxkpi/common/include/linux/kstrtox.h
+++ b/sys/compat/linuxkpi/common/include/linux/kstrtox.h
@@ -1,0 +1,335 @@
+/*-
+ * Copyright (c) 2010 Isilon Systems, Inc.
+ * Copyright (c) 2010 iX Systems, Inc.
+ * Copyright (c) 2010 Panasas, Inc.
+ * Copyright (c) 2017-2018 Mellanox Technologies, Ltd.
+ * All rights reserved.
+ * Copyright (c) 2018 Johannes Lundberg <johalun0@gmail.com>
+ * Copyright (c) 2020-2022 The FreeBSD Foundation
+ * Copyright (c) 2021 Vladimir Kondratyev <wulf@FreeBSD.org>
+ * Copyright (c) 2023 Serenity Cyber Security, LLC
+ *
+ * Portions of this software were developed by Bjoern A. Zeeb and
+ * Emmanuel Vadot under sponsorship from the FreeBSD Foundation.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice unmodified, this list of conditions, and the following
+ *    disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef	_LINUXKPI_LINUX_KSTRTOX_H_
+#define	_LINUXKPI_LINUX_KSTRTOX_H_
+
+#include <sys/types.h>
+#include <sys/errno.h>
+#include <sys/libkern.h>
+
+#include <linux/compiler.h>
+#include <linux/types.h>
+
+#include <asm/uaccess.h>
+
+static inline unsigned long long
+simple_strtoull(const char *cp, char **endp, unsigned int base)
+{
+	return (strtouq(cp, endp, base));
+}
+
+static inline long long
+simple_strtoll(const char *cp, char **endp, unsigned int base)
+{
+	return (strtoq(cp, endp, base));
+}
+
+static inline unsigned long
+simple_strtoul(const char *cp, char **endp, unsigned int base)
+{
+	return (strtoul(cp, endp, base));
+}
+
+static inline long
+simple_strtol(const char *cp, char **endp, unsigned int base)
+{
+	return (strtol(cp, endp, base));
+}
+
+static inline int
+kstrtoul(const char *cp, unsigned int base, unsigned long *res)
+{
+	char *end;
+	unsigned long temp;
+
+	temp = strtoul(cp, &end, base);
+
+	/* skip newline character, if any */
+	if (*end == '\n')
+		end++;
+	if (*cp == 0 || *end != 0)
+		return (-EINVAL);
+
+	*res = temp;
+	return (0);
+}
+
+static inline int
+kstrtol(const char *cp, unsigned int base, long *res)
+{
+	char *end;
+	long temp;
+
+	temp = strtol(cp, &end, base);
+
+	/* skip newline character, if any */
+	if (*end == '\n')
+		end++;
+	if (*cp == 0 || *end != 0)
+		return (-EINVAL);
+
+	*res = temp;
+	return (0);
+}
+
+static inline int
+kstrtoint(const char *cp, unsigned int base, int *res)
+{
+	char *end;
+	long temp;
+
+	temp = strtol(cp, &end, base);
+
+	/* skip newline character, if any */
+	if (*end == '\n')
+		end++;
+	if (*cp == 0 || *end != 0)
+		return (-EINVAL);
+	if (temp != (int)temp)
+		return (-ERANGE);
+
+	*res = (int)temp;
+	return (0);
+}
+
+static inline int
+kstrtouint(const char *cp, unsigned int base, unsigned int *res)
+{
+	char *end;
+	unsigned long temp;
+
+	temp = strtoul(cp, &end, base);
+
+	/* skip newline character, if any */
+	if (*end == '\n')
+		end++;
+	if (*cp == 0 || *end != 0)
+		return (-EINVAL);
+	if (temp != (unsigned int)temp)
+		return (-ERANGE);
+
+	*res = (unsigned int)temp;
+	return (0);
+}
+
+static inline int
+kstrtou8(const char *cp, unsigned int base, uint8_t *res)
+{
+	char *end;
+	unsigned long temp;
+
+	temp = strtoul(cp, &end, base);
+
+	/* skip newline character, if any */
+	if (*end == '\n')
+		end++;
+	if (*cp == 0 || *end != 0)
+		return (-EINVAL);
+	if (temp != (uint8_t)temp)
+		return (-ERANGE);
+
+	*res = (uint8_t)temp;
+	return (0);
+}
+
+static inline int
+kstrtou16(const char *cp, unsigned int base, uint16_t *res)
+{
+	char *end;
+	unsigned long temp;
+
+	temp = strtoul(cp, &end, base);
+
+	/* skip newline character, if any */
+	if (*end == '\n')
+		end++;
+	if (*cp == 0 || *end != 0)
+		return (-EINVAL);
+	if (temp != (uint16_t)temp)
+		return (-ERANGE);
+
+	*res = (uint16_t)temp;
+	return (0);
+}
+
+static inline int
+kstrtou32(const char *cp, unsigned int base, uint32_t *res)
+{
+	return (kstrtouint(cp, base, res));
+}
+
+static inline int
+kstrtos32(const char *cp, unsigned int base, int32_t *res)
+{
+	return (kstrtoint(cp, base, res));
+}
+
+static inline int
+kstrtos64(const char *cp, unsigned int base, int64_t *res)
+{
+	char *end;
+	quad_t temp;
+
+	temp = strtoq(cp, &end, base);
+
+	/* skip newline character, if any */
+	if (*end == '\n')
+		end++;
+	if (*cp == 0 || *end != 0)
+		return (-EINVAL);
+
+	*res = (int64_t)temp;
+	return (0);
+}
+
+static inline int
+kstrtoll(const char *cp, unsigned int base, long long *res)
+{
+	return (kstrtos64(cp, base, (int64_t *)res));
+}
+
+static inline int
+kstrtou64(const char *cp, unsigned int base, uint64_t *res)
+{
+	char *end;
+	u_quad_t temp;
+
+	temp = strtouq(cp, &end, base);
+
+	/* skip newline character, if any */
+	if (*end == '\n')
+		end++;
+	if (*cp == 0 || *end != 0)
+		return (-EINVAL);
+
+	*res = (uint64_t)temp;
+	return (0);
+}
+
+static inline int
+kstrtoull(const char *cp, unsigned int base, unsigned long long *res)
+{
+	return (kstrtou64(cp, base, (uint64_t *)res));
+}
+
+static inline int
+kstrtobool(const char *s, bool *res)
+{
+	if (s == NULL || *s == '\0')
+		return (-EINVAL);
+
+	if (strchr("eEtTyY1", s[0]) != NULL)
+		*res = true;
+	else if (strchr("dDfFnN0", s[0]) != NULL)
+		*res = false;
+	else if (strncasecmp("on", s, 2) == 0)
+		*res = true;
+	else if (strncasecmp("of", s, 2) == 0)
+		*res = false;
+	else
+		return (-EINVAL);
+
+	return (0);
+}
+
+static inline int
+kstrtobool_from_user(const char __user *s, size_t count, bool *res)
+{
+	char buf[8] = {};
+
+	if (count > (sizeof(buf) - 1))
+		count = (sizeof(buf) - 1);
+
+	if (copy_from_user(buf, s, count))
+		return (-EFAULT);
+
+	return (kstrtobool(buf, res));
+}
+
+static inline int
+kstrtoint_from_user(const char __user *s, size_t count, unsigned int base,
+    int *p)
+{
+	char buf[36] = {};
+
+	if (count > (sizeof(buf) - 1))
+		count = (sizeof(buf) - 1);
+
+	if (copy_from_user(buf, s, count))
+		return (-EFAULT);
+
+	return (kstrtoint(buf, base, p));
+}
+
+static inline int
+kstrtouint_from_user(const char __user *s, size_t count, unsigned int base,
+    unsigned int *p)
+{
+	char buf[36] = {};
+
+	if (count > (sizeof(buf) - 1))
+		count = (sizeof(buf) - 1);
+
+	if (copy_from_user(buf, s, count))
+		return (-EFAULT);
+
+	return (kstrtouint(buf, base, p));
+}
+
+static inline int
+kstrtou32_from_user(const char __user *s, size_t count, unsigned int base,
+    unsigned int *p)
+{
+	return (kstrtouint_from_user(s, count, base, p));
+}
+
+static inline int
+kstrtou8_from_user(const char __user *s, size_t count, unsigned int base,
+    uint8_t *p)
+{
+	char buf[8] = {};
+
+	if (count > (sizeof(buf) - 1))
+		count = (sizeof(buf) - 1);
+
+	if (copy_from_user(buf, s, count))
+		return (-EFAULT);
+
+	return (kstrtou8(buf, base, p));
+}
+
+#endif	/* _LINUXKPI_LINUX_KSTRTOX_H_ */

--- a/sys/compat/linuxkpi/common/include/linux/limits.h
+++ b/sys/compat/linuxkpi/common/include/linux/limits.h
@@ -1,0 +1,47 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2023 Serenity Cyber Security, LLC.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#ifndef _LINUXKPI_LINUX_LIMITS_H
+#define	_LINUXKPI_LINUX_LIMITS_H
+
+#include <sys/types.h>
+#include <sys/stdint.h>
+
+#define	U8_MAX		UINT8_MAX
+#define	S8_MAX		INT8_MAX
+#define	S8_MIN		INT8_MIN
+#define	U16_MAX		UINT16_MAX
+#define	S16_MAX		INT16_MAX
+#define	S16_MIN		INT16_MIN
+#define	U32_MAX		UINT32_MAX
+#define	S32_MAX		INT32_MAX
+#define	S32_MIN		INT32_MIN
+#define	U64_MAX		UINT64_MAX
+#define	S64_MAX		INT64_MAX
+#define	S64_MIN		INT64_MIN
+
+#endif

--- a/sys/compat/linuxkpi/common/include/linux/math.h
+++ b/sys/compat/linuxkpi/common/include/linux/math.h
@@ -1,0 +1,76 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2013-2015 Mellanox Technologies, Ltd.
+ * Copyright (c) 2014-2015 François Tigeot
+ * Copyright (c) 2016 Matt Macy <mmacy@FreeBSD.org>
+ * Copyright (c) 2019 Johannes Lundberg <johalun@FreeBSD.org>
+ * Copyright (c) 2023 Serenity Cyber Security, LLC.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#ifndef _LINUXKPI_LINUX_MATH_H_
+#define	_LINUXKPI_LINUX_MATH_H_
+
+#include <linux/types.h>
+
+/*
+ * This looks more complex than it should be. But we need to
+ * get the type for the ~ right in round_down (it needs to be
+ * as wide as the result!), and we want to evaluate the macro
+ * arguments just once each.
+ */
+#define	__round_mask(x, y)	((__typeof__(x))((y)-1))
+#define	round_up(x, y)		((((x)-1) | __round_mask(x, y))+1)
+#define	round_down(x, y)	((x) & ~__round_mask(x, y))
+
+#define	DIV_ROUND_UP(x, n)	howmany(x, n)
+#define	DIV_ROUND_UP_ULL(x, n)	DIV_ROUND_UP((unsigned long long)(x), (n))
+#define	DIV_ROUND_DOWN_ULL(x, n) ((unsigned long long)(x) / (n))
+
+#define	DIV_ROUND_CLOSEST(x, divisor)	(((x) + ((divisor) / 2)) / (divisor))
+#define	DIV_ROUND_CLOSEST_ULL(x, divisor) ({		\
+	__typeof(divisor) __d = (divisor);		\
+	unsigned long long __ret = (x) + (__d) / 2;	\
+	__ret /= __d;					\
+	__ret;						\
+})
+
+#if !defined(LINUXKPI_VERSION) || (LINUXKPI_VERSION >= 60600)
+#define abs_diff(x, y) ({		\
+	__typeof(x) _x = (x);		\
+	__typeof(y) _y = (y);		\
+	_x > _y ? _x - _y : _y - _x;	\
+})
+#endif
+
+static inline uintmax_t
+mult_frac(uintmax_t x, uintmax_t multiplier, uintmax_t divisor)
+{
+	uintmax_t q = (x / divisor);
+	uintmax_t r = (x % divisor);
+
+	return ((q * multiplier) + ((r * multiplier) / divisor));
+}
+
+#endif /* _LINUXKPI_LINUX_MATH_H_ */

--- a/sys/compat/linuxkpi/common/include/linux/minmax.h
+++ b/sys/compat/linuxkpi/common/include/linux/minmax.h
@@ -1,0 +1,74 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2010 iX Systems, Inc.
+ * Copyright (c) 2010 Panasas, Inc.
+ * Copyright (c) 2013-2015 Mellanox Technologies, Ltd.
+ * Copyright (c) 2014-2015 François Tigeot
+ * Copyright (c) 2015 Hans Petter Selasky <hselasky@FreeBSD.org>
+ * Copyright (c) 2016 Matt Macy <mmacy@FreeBSD.org>
+ * Copyright (c) 2023 Serenity Cyber Security, LLC.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#ifndef _LINUXKPI_LINUX_MINMAX_H_
+#define	_LINUXKPI_LINUX_MINMAX_H_
+
+#include <linux/build_bug.h>
+#include <linux/compiler.h>
+#include <linux/types.h>
+
+#define	min(x, y)	((x) < (y) ? (x) : (y))
+#define	max(x, y)	((x) > (y) ? (x) : (y))
+
+#define	min3(a, b, c)	min(a, min(b, c))
+#define	max3(a, b, c)	max(a, max(b, c))
+
+#define min_not_zero(x, y) ({						\
+	__typeof(x) __min1 = (x);					\
+	__typeof(y) __min2 = (y);					\
+	__min1 == 0 ? __min2 : ((__min2 == 0) ? __min1 : min(__min1, __min2));\
+})
+
+#define	min_t(type, x, y) ({			\
+	type __min1 = (x);			\
+	type __min2 = (y);			\
+	__min1 < __min2 ? __min1 : __min2; })
+
+#define	max_t(type, x, y) ({			\
+	type __max1 = (x);			\
+	type __max2 = (y);			\
+	__max1 > __max2 ? __max1 : __max2; })
+
+#define	clamp_t(type, _x, min, max)	min_t(type, max_t(type, _x, min), max)
+#define	clamp(x, lo, hi)		min(max(x, lo), hi)
+#define	clamp_val(val, lo, hi)	clamp_t(typeof(val), val, lo, hi)
+
+/* Swap values of a and b */
+#define swap(a, b) do {			\
+	__typeof(a) _swap_tmp = a;	\
+	a = b;				\
+	b = _swap_tmp;			\
+} while (0)
+
+#endif /* _LINUXKPI_LINUX_MINMAX_H_ */

--- a/sys/compat/linuxkpi/common/include/linux/mm.h
+++ b/sys/compat/linuxkpi/common/include/linux/mm.h
@@ -138,7 +138,7 @@ struct vm_fault {
 struct vm_operations_struct {
 	void    (*open) (struct vm_area_struct *);
 	void    (*close) (struct vm_area_struct *);
-	int     (*fault) (struct vm_area_struct *, struct vm_fault *);
+	int     (*fault) (struct vm_fault *);
 	int	(*access) (struct vm_area_struct *, unsigned long, void *, int, int);
 };
 

--- a/sys/compat/linuxkpi/common/include/linux/nodemask.h
+++ b/sys/compat/linuxkpi/common/include/linux/nodemask.h
@@ -1,0 +1,40 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2023 Serenity Cyber Security, LLC.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#ifndef _LINUXKPI_LINUX_NODEMASK_H_
+#define	_LINUXKPI_LINUX_NODEMASK_H_
+
+#include <linux/kernel.h>	/* pr_debug */
+
+static inline int
+num_possible_nodes(void)
+{
+	pr_debug("%s: TODO\n", __func__);
+	return (1);
+}
+
+#endif /* _LINUXKPI_LINUX_NODEMASK_H_ */

--- a/sys/compat/linuxkpi/common/include/linux/of.h
+++ b/sys/compat/linuxkpi/common/include/linux/of.h
@@ -1,0 +1,33 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2023 Serenity Cyber Security, LLC.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#ifndef _LINUXKPI_LINUX_OF_H
+#define	_LINUXKPI_LINUX_OF_H
+
+#include <linux/kobject.h>
+
+#endif

--- a/sys/compat/linuxkpi/common/include/linux/pci.h
+++ b/sys/compat/linuxkpi/common/include/linux/pci.h
@@ -1401,6 +1401,12 @@ pcie_bandwidth_available(struct pci_dev *pdev,
 	return (nwidth * PCIE_SPEED2MBS_ENC(nspeed));
 }
 
+static inline bool
+pcie_aspm_enabled(struct pci_dev *pdev)
+{
+	return (false);
+}
+
 static inline struct pci_dev *
 pcie_find_root_port(struct pci_dev *pdev)
 {

--- a/sys/compat/linuxkpi/common/include/linux/pci.h
+++ b/sys/compat/linuxkpi/common/include/linux/pci.h
@@ -220,6 +220,8 @@ typedef int pci_power_t;
 #define PCI_D3hot	PCI_POWERSTATE_D3
 #define PCI_D3cold	4
 
+extern const char *pci_power_names[6];
+
 #define PCI_POWER_ERROR	PCI_POWERSTATE_UNKNOWN
 
 #define	PCI_ERR_ROOT_COMMAND		PCIR_AER_ROOTERR_CMD
@@ -341,6 +343,7 @@ struct pci_dev {
 	struct list_head	links;
 	struct pci_driver	*pdrv;
 	struct pci_bus		*bus;
+	pci_power_t		current_state;
 	uint16_t		device;
 	uint16_t		vendor;
 	uint16_t		subsystem_vendor;
@@ -1399,6 +1402,17 @@ pcie_bandwidth_available(struct pci_dev *pdev,
 		*width = nwidth;
 
 	return (nwidth * PCIE_SPEED2MBS_ENC(nspeed));
+}
+
+static inline const char *
+pci_power_name(pci_power_t state)
+{
+	int pstate = state + 1;
+
+	if (pstate >= 0 && pstate < nitems(pci_power_names))
+		return (pci_power_names[pstate]);
+	else
+		return (pci_power_names[0]);
 }
 
 static inline bool

--- a/sys/compat/linuxkpi/common/include/linux/pm.h
+++ b/sys/compat/linuxkpi/common/include/linux/pm.h
@@ -40,6 +40,10 @@
 
 struct device;
 
+struct dev_pm_info {
+	atomic_t usage_count;
+};
+
 typedef struct pm_message {
 	int event;
 } pm_message_t;

--- a/sys/compat/linuxkpi/common/include/linux/slab.h
+++ b/sys/compat/linuxkpi/common/include/linux/slab.h
@@ -88,7 +88,8 @@ struct linux_kmem_cache;
 /* drm-kmod 5.4 compat */
 #define kfree_async(ptr)	kfree(ptr);
 
-#define ZERO_OR_NULL_PTR(x)	((x) == NULL)
+#define	ZERO_SIZE_PTR		((void *)16)
+#define ZERO_OR_NULL_PTR(x)	((x) == NULL || (x) == ZERO_SIZE_PTR)
 
 static inline gfp_t
 linux_check_m_flags(gfp_t flags)

--- a/sys/compat/linuxkpi/common/include/linux/soc/mediatek/mtk_wed.h
+++ b/sys/compat/linuxkpi/common/include/linux/soc/mediatek/mtk_wed.h
@@ -1,0 +1,71 @@
+/*-
+ * Copyright (c) 2022-2025 Bjoern A. Zeeb
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#ifndef	_LINUXKPI_LINUX_SOC_MEDIATEK_MTK_WED_H
+#define	_LINUXKPI_LINUX_SOC_MEDIATEK_MTK_WED_H
+
+#include <linux/kernel.h>	/* pr_debug */
+
+struct mtk_wed_device {
+};
+
+#define	WED_WO_STA_REC	0x6
+
+#if defined(CONFIG_NET_MEDIATEK_SOC_WED)
+#define	mtk_wed_device_start(_dev, _mask)		do { pr_debug("%s: TODO\n", __func__); } while(0)
+#define	mtk_wed_device_detach(_dev)			do { pr_debug("%s: TODO\n", __func__); } while(0)
+#define	mtk_wed_device_irq_get(_dev, _mask)		0
+#define	mtk_wed_device_irq_set_mask(_dev, _mask)	do { pr_debug("%s: TODO\n", __func__); } while(0)
+#define	mtk_wed_device_update_msg(_dev, _id, _msg, _len)	({ pr_debug("%s: TODO\n", __func__); -ENODEV; })
+#define	mtk_wed_device_dma_reset(_dev)			do { pr_debug("%s: TODO\n", __func__); } while (0)
+#define	mtk_wed_device_ppe_check(_dev, _skb, _reason, _entry) \
+    do { pr_debug("%s: TODO\n", __func__); } while (0)
+#define	mtk_wed_device_stop(_dev)			do { pr_debug("%s: TODO\n", __func__); } while(0)
+#define	mtk_wed_device_start_hw_rro(_dev, _mask, _b)	do { pr_debug("%s: TODO\n", __func__); } while(0)
+#define	mtk_wed_device_setup_tc(_dev, _ndev, _type, _tdata)	({ pr_debug("%s: TODO\n", __func__); -EOPNOTSUPP; })
+
+static inline bool
+mtk_wed_device_active(struct mtk_wed_device *dev __unused)
+{
+	pr_debug("%s: TODO\n", __func__);
+	return (false);
+}
+
+static inline bool
+mtk_wed_get_rx_capa(struct mtk_wed_device *dev __unused)
+{
+
+	pr_debug("%s: TODO\n", __func__);
+	return (false);
+}
+
+#else	/* ! CONFIG_NET_MEDIATEK_SOC_WED */
+
+#define	mtk_wed_device_start(_dev, _mask)		do { } while(0)
+#define	mtk_wed_device_detach(_dev)			do { } while(0)
+#define	mtk_wed_device_irq_get(_dev, _mask)		0
+#define	mtk_wed_device_irq_set_mask(_dev, _mask)	do { } while(0)
+#define	mtk_wed_device_update_msg(_dev, _id, _msg, _len)	-ENODEV
+#define	mtk_wed_device_dma_reset(_dev)			do { } while (0)
+#define	mtk_wed_device_ppe_check(_dev, _skb, _reason, _entry) do { } while (0)
+#define	mtk_wed_device_stop(_dev)			do { } while(0)
+#define	mtk_wed_device_start_hw_rro(_dev, _mask, _b)	do { } while(0)
+#define	mtk_wed_device_setup_tc(_dev, _ndev, _type, _tdata)	-EOPNOTSUPP
+
+static inline bool
+mtk_wed_device_active(struct mtk_wed_device *dev __unused)
+{
+	return (false);
+}
+
+static inline bool
+mtk_wed_get_rx_capa(struct mtk_wed_device *dev __unused)
+{
+	return (false);
+}
+#endif	/* CONFIG_NET_MEDIATEK_SOC_WED */
+
+#endif	/* _LINUXKPI_LINUX_SOC_MEDIATEK_MTK_WED_H */

--- a/sys/compat/linuxkpi/common/include/linux/string_helpers.h
+++ b/sys/compat/linuxkpi/common/include/linux/string_helpers.h
@@ -1,0 +1,71 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2023 Jean-Sébastien Pédron <dumbbell@FreeBSD.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice unmodified, this list of conditions, and the following
+ *    disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef	_LINUXKPI_LINUX_STRING_HELPERS_H_
+#define	_LINUXKPI_LINUX_STRING_HELPERS_H_
+
+#include <sys/types.h>
+
+static inline const char *
+str_yes_no(bool value)
+{
+	if (value)
+		return "yes";
+	else
+		return "no";
+}
+
+static inline const char *
+str_on_off(bool value)
+{
+	if (value)
+		return "on";
+	else
+		return "off";
+}
+
+static inline const char *
+str_enabled_disabled(bool value)
+{
+	if (value)
+		return "enabled";
+	else
+		return "disabled";
+}
+
+static inline const char *
+str_enable_disable(bool value)
+{
+	if (value)
+		return "enable";
+	else
+		return "disable";
+}
+
+#define	str_disable_enable(_v)		str_enable_disable(!(_v))
+
+#endif

--- a/sys/compat/linuxkpi/common/include/net/netmem.h
+++ b/sys/compat/linuxkpi/common/include/net/netmem.h
@@ -1,0 +1,21 @@
+/*-
+ * Copyright (c) 2023-2025 Bjoern A. Zeeb
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#ifndef	_LINUXKPI_NET_NETMEM_H
+#define	_LINUXKPI_NET_NETMEM_H
+
+struct page_pool;
+
+struct netmem_desc {
+	struct page_pool	*pp;
+};
+
+#define	pp_page_to_nmdesc(page)						\
+    (_Generic((page),							\
+	const struct page *:	(const struct netmem_desc *)(page),	\
+	struct page *:		(struct netmem_desc *)(page)))
+
+#endif	/* _LINUXKPI_NET_NETMEM_H */

--- a/sys/compat/linuxkpi/common/include/net/page_pool/helpers.h
+++ b/sys/compat/linuxkpi/common/include/net/page_pool/helpers.h
@@ -1,0 +1,79 @@
+/*-
+ * Copyright (c) 2023-2025 Bjoern A. Zeeb
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#ifndef	_LINUXKPI_NET_PAGE_POOL_HELPERS_H
+#define	_LINUXKPI_NET_PAGE_POOL_HELPERS_H
+
+#include <linux/kernel.h>	/* pr_debug */
+#include <linux/types.h>
+#include <linux/dma-mapping.h>
+#include <net/page_pool/types.h>
+
+static inline struct page_pool *
+page_pool_create(const struct page_pool_params *ppparams)
+{
+
+	pr_debug("%s: TODO\n", __func__);
+	return (NULL);
+}
+
+static inline void
+page_pool_destroy(struct page_pool *ppool)
+{
+
+	pr_debug("%s: TODO\n", __func__);
+}
+
+static inline struct page *
+page_pool_dev_alloc_frag(struct page_pool *ppool, uint32_t *offset,
+    size_t size)
+{
+
+	pr_debug("%s: TODO\n", __func__);
+	return (NULL);
+}
+
+static inline dma_addr_t
+page_pool_get_dma_addr(struct page *page)
+{
+
+	pr_debug("%s: TODO\n", __func__);
+	return (0);
+}
+
+static inline enum dma_data_direction
+page_pool_get_dma_dir(const struct page_pool *ppool)
+{
+
+	pr_debug("%s: TODO\n", __func__);
+	return (DMA_BIDIRECTIONAL);
+}
+
+static inline void
+page_pool_put_full_page(struct page_pool *ppool, struct page *page,
+    bool allow_direct)
+{
+
+	pr_debug("%s: TODO\n", __func__);
+}
+
+static inline int
+page_pool_ethtool_stats_get_count(void)
+{
+
+	pr_debug("%s: TODO\n", __func__);
+	return (0);
+}
+
+static inline uint8_t *
+page_pool_ethtool_stats_get_strings(uint8_t *x)
+{
+
+	pr_debug("%s: TODO\n", __func__);
+	return (x);
+}
+
+#endif	/* _LINUXKPI_NET_PAGE_POOL_HELPERS_H */

--- a/sys/compat/linuxkpi/common/include/net/page_pool/types.h
+++ b/sys/compat/linuxkpi/common/include/net/page_pool/types.h
@@ -1,0 +1,36 @@
+/*-
+ * Copyright (c) 2023-2025 Bjoern A. Zeeb
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#ifndef	_LINUXKPI_NET_PAGE_POOL_TYPES_H
+#define	_LINUXKPI_NET_PAGE_POOL_TYPES_H
+
+#include <linux/types.h>
+#include <linux/dma-mapping.h>
+#include <net/netmem.h>
+
+struct device;
+struct napi_struct;
+
+struct page_pool_params {
+	struct device			*dev;
+	uint32_t			flags;
+	uint32_t			order;
+	uint32_t			pool_size;
+	uint32_t			max_len;
+	uint32_t			offset;
+	int				nid;		/* NUMA */
+	enum dma_data_direction		dma_dir;
+	struct napi_struct		*napi;
+};
+
+struct page_pool {
+};
+
+#define	PP_FLAG_DMA_MAP		BIT(0)
+#define	PP_FLAG_DMA_SYNC_DEV	BIT(1)
+#define	PP_FLAG_PAGE_FRAG	BIT(2)
+
+#endif	/* _LINUXKPI_NET_PAGE_POOL_TYPES_H */

--- a/sys/compat/linuxkpi/common/include/video/cmdline.h
+++ b/sys/compat/linuxkpi/common/include/video/cmdline.h
@@ -1,0 +1,44 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2023 Serenity Cyber Security, LLC.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#ifndef _VIDEO_CMDLINE_H_
+#define _VIDEO_CMDLINE_H_
+
+#include <linux/types.h>
+
+#define CONFIG_VIDEO_CMDLINE
+
+#if defined(CONFIG_VIDEO_CMDLINE)
+const char *video_get_options(const char *name);
+#else
+static inline const char *
+video_get_options(const char *name)
+{
+	return (NULL);
+}
+#endif
+#endif /* _VIDEO_CMDLINE_H_ */

--- a/sys/compat/linuxkpi/common/include/video/vga.h
+++ b/sys/compat/linuxkpi/common/include/video/vga.h
@@ -1,0 +1,16 @@
+/* Public domain. */
+
+#ifndef _LINUXKPI_VIDEO_VGA_H
+#define _LINUXKPI_VIDEO_VGA_H
+
+#define VGA_MIS_W	0x3c2
+#define VGA_SEQ_I	0x3c4
+#define VGA_SEQ_D	0x3c5
+#define VGA_MIS_R	0x3cc
+
+#define VGA_SR01_SCREEN_OFF	(1 << 5)
+
+#define VGA_FB_PHYS_BASE	0xA0000
+#define VGA_FB_PHYS_SIZE	65536
+
+#endif

--- a/sys/compat/linuxkpi/common/include/xen/xen.h
+++ b/sys/compat/linuxkpi/common/include/xen/xen.h
@@ -1,0 +1,37 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2023 Serenity Cyber Security, LLC.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#ifndef _LINUXKPI_XEN_XEN_H_
+#define	_LINUXKPI_XEN_XEN_H_
+
+#define xen_initial_domain()	lkpi_xen_initial_domain()
+#define	xen_pv_domain()		lkpi_xen_pv_domain()
+
+bool lkpi_xen_initial_domain(void);
+bool lkpi_xen_pv_domain(void);
+
+#endif /* _LINUXKPI_XEN_XEN_H_ */

--- a/sys/compat/linuxkpi/common/src/linux_aperture.c
+++ b/sys/compat/linuxkpi/common/src/linux_aperture.c
@@ -1,0 +1,387 @@
+// SPDX-License-Identifier: MIT
+
+#include <linux/aperture.h>
+#include <linux/device.h>
+#include <linux/list.h>
+#include <linux/mutex.h>
+#include <linux/pci.h>
+#include <linux/platform_device.h>
+#include <linux/slab.h>
+#include <linux/sysfb.h>
+#include <linux/types.h>
+#include <linux/vgaarb.h>
+
+#include <video/vga.h>
+
+/**
+ * DOC: overview
+ *
+ * A graphics device might be supported by different drivers, but only one
+ * driver can be active at any given time. Many systems load a generic
+ * graphics drivers, such as EFI-GOP or VESA, early during the boot process.
+ * During later boot stages, they replace the generic driver with a dedicated,
+ * hardware-specific driver. To take over the device, the dedicated driver
+ * first has to remove the generic driver. Aperture functions manage
+ * ownership of framebuffer memory and hand-over between drivers.
+ *
+ * Graphics drivers should call aperture_remove_conflicting_devices()
+ * at the top of their probe function. The function removes any generic
+ * driver that is currently associated with the given framebuffer memory.
+ * An example for a graphics device on the platform bus is shown below.
+ *
+ * .. code-block:: c
+ *
+ *	static int example_probe(struct platform_device *pdev)
+ *	{
+ *		struct resource *mem;
+ *		resource_size_t base, size;
+ *		int ret;
+ *
+ *		mem = platform_get_resource(pdev, IORESOURCE_MEM, 0);
+ *		if (!mem)
+ *			return -ENODEV;
+ *		base = mem->start;
+ *		size = resource_size(mem);
+ *
+ *		ret = aperture_remove_conflicting_devices(base, size, "example");
+ *		if (ret)
+ *			return ret;
+ *
+ *		// Initialize the hardware
+ *		...
+ *
+ *		return 0;
+ *	}
+ *
+ *	static const struct platform_driver example_driver = {
+ *		.probe = example_probe,
+ *		...
+ *	};
+ *
+ * The given example reads the platform device's I/O-memory range from the
+ * device instance. An active framebuffer will be located within this range.
+ * The call to aperture_remove_conflicting_devices() releases drivers that
+ * have previously claimed ownership of the range and are currently driving
+ * output on the framebuffer. If successful, the new driver can take over
+ * the device.
+ *
+ * While the given example uses a platform device, the aperture helpers work
+ * with every bus that has an addressable framebuffer. In the case of PCI,
+ * device drivers can also call aperture_remove_conflicting_pci_devices() and
+ * let the function detect the apertures automatically. Device drivers without
+ * knowledge of the framebuffer's location can call
+ * aperture_remove_all_conflicting_devices(), which removes all known devices.
+ *
+ * Drivers that are susceptible to being removed by other drivers, such as
+ * generic EFI or VESA drivers, have to register themselves as owners of their
+ * framebuffer apertures. Ownership of the framebuffer memory is achieved
+ * by calling devm_aperture_acquire_for_platform_device(). If successful, the
+ * driver is the owner of the framebuffer range. The function fails if the
+ * framebuffer is already owned by another driver. See below for an example.
+ *
+ * .. code-block:: c
+ *
+ *	static int generic_probe(struct platform_device *pdev)
+ *	{
+ *		struct resource *mem;
+ *		resource_size_t base, size;
+ *
+ *		mem = platform_get_resource(pdev, IORESOURCE_MEM, 0);
+ *		if (!mem)
+ *			return -ENODEV;
+ *		base = mem->start;
+ *		size = resource_size(mem);
+ *
+ *		ret = devm_aperture_acquire_for_platform_device(pdev, base, size);
+ *		if (ret)
+ *			return ret;
+ *
+ *		// Initialize the hardware
+ *		...
+ *
+ *		return 0;
+ *	}
+ *
+ *	static int generic_remove(struct platform_device *)
+ *	{
+ *		// Hot-unplug the device
+ *		...
+ *
+ *		return 0;
+ *	}
+ *
+ *	static const struct platform_driver generic_driver = {
+ *		.probe = generic_probe,
+ *		.remove = generic_remove,
+ *		...
+ *	};
+ *
+ * The similar to the previous example, the generic driver claims ownership
+ * of the framebuffer memory from its probe function. This will fail if the
+ * memory range, or parts of it, is already owned by another driver.
+ *
+ * If successful, the generic driver is now subject to forced removal by
+ * another driver. This only works for platform drivers that support hot
+ * unplugging. When a driver calls aperture_remove_conflicting_devices()
+ * et al for the registered framebuffer range, the aperture helpers call
+ * platform_device_unregister() and the generic driver unloads itself. The
+ * generic driver also has to provide a remove function to make this work.
+ * Once hot unplugged from hardware, it may not access the device's
+ * registers, framebuffer memory, ROM, etc afterwards.
+ */
+
+struct aperture_range {
+	struct device *dev;
+	resource_size_t base;
+	resource_size_t size;
+	struct list_head lh;
+	void (*detach)(struct device *dev);
+};
+
+static LIST_HEAD(apertures);
+static DEFINE_MUTEX(apertures_lock);
+
+static bool overlap(resource_size_t base1, resource_size_t end1,
+		    resource_size_t base2, resource_size_t end2)
+{
+	return (base1 < end2) && (end1 > base2);
+}
+
+static void devm_aperture_acquire_release(void *data)
+{
+	struct aperture_range *ap = data;
+	bool detached = !ap->dev;
+
+	if (detached)
+		return;
+
+	mutex_lock(&apertures_lock);
+	list_del(&ap->lh);
+	mutex_unlock(&apertures_lock);
+}
+
+static int devm_aperture_acquire(struct device *dev,
+				 resource_size_t base, resource_size_t size,
+				 void (*detach)(struct device *))
+{
+	size_t end = base + size;
+	struct list_head *pos;
+	struct aperture_range *ap;
+
+	mutex_lock(&apertures_lock);
+
+	list_for_each(pos, &apertures) {
+		ap = container_of(pos, struct aperture_range, lh);
+		if (overlap(base, end, ap->base, ap->base + ap->size)) {
+			mutex_unlock(&apertures_lock);
+			return -EBUSY;
+		}
+	}
+
+	ap = devm_kzalloc(dev, sizeof(*ap), GFP_KERNEL);
+	if (!ap) {
+		mutex_unlock(&apertures_lock);
+		return -ENOMEM;
+	}
+
+	ap->dev = dev;
+	ap->base = base;
+	ap->size = size;
+	ap->detach = detach;
+	INIT_LIST_HEAD(&ap->lh);
+
+	list_add(&ap->lh, &apertures);
+
+	mutex_unlock(&apertures_lock);
+
+	return devm_add_action_or_reset(dev, devm_aperture_acquire_release, ap);
+}
+
+static void aperture_detach_platform_device(struct device *dev)
+{
+	struct platform_device *pdev = to_platform_device(dev);
+
+	/*
+	 * Remove the device from the device hierarchy. This is the right thing
+	 * to do for firmware-based fb drivers, such as EFI, VESA or VGA. After
+	 * the new driver takes over the hardware, the firmware device's state
+	 * will be lost.
+	 *
+	 * For non-platform devices, a new callback would be required.
+	 *
+	 * If the aperture helpers ever need to handle native drivers, this call
+	 * would only have to unplug the DRM device, so that the hardware device
+	 * stays around after detachment.
+	 */
+	platform_device_unregister(pdev);
+}
+
+/**
+ * devm_aperture_acquire_for_platform_device - Acquires ownership of an aperture
+ *                                             on behalf of a platform device.
+ * @pdev:	the platform device to own the aperture
+ * @base:	the aperture's byte offset in physical memory
+ * @size:	the aperture size in bytes
+ *
+ * Installs the given device as the new owner of the aperture. The function
+ * expects the aperture to be provided by a platform device. If another
+ * driver takes over ownership of the aperture, aperture helpers will then
+ * unregister the platform device automatically. All acquired apertures are
+ * released automatically when the underlying device goes away.
+ *
+ * The function fails if the aperture, or parts of it, is currently
+ * owned by another device. To evict current owners, callers should use
+ * remove_conflicting_devices() et al. before calling this function.
+ *
+ * Returns:
+ * 0 on success, or a negative errno value otherwise.
+ */
+int devm_aperture_acquire_for_platform_device(struct platform_device *pdev,
+					      resource_size_t base,
+					      resource_size_t size)
+{
+	return devm_aperture_acquire(&pdev->dev, base, size, aperture_detach_platform_device);
+}
+EXPORT_SYMBOL(devm_aperture_acquire_for_platform_device);
+
+static void aperture_detach_devices(resource_size_t base, resource_size_t size)
+{
+	resource_size_t end = base + size;
+	struct list_head *pos, *n;
+
+	mutex_lock(&apertures_lock);
+
+	list_for_each_safe(pos, n, &apertures) {
+		struct aperture_range *ap = container_of(pos, struct aperture_range, lh);
+		struct device *dev = ap->dev;
+
+		if (WARN_ON_ONCE(!dev))
+			continue;
+
+		if (!overlap(base, end, ap->base, ap->base + ap->size))
+			continue;
+
+		ap->dev = NULL; /* detach from device */
+		list_del(&ap->lh);
+
+		ap->detach(dev);
+	}
+
+	mutex_unlock(&apertures_lock);
+}
+
+/**
+ * aperture_remove_conflicting_devices - remove devices in the given range
+ * @base: the aperture's base address in physical memory
+ * @size: aperture size in bytes
+ * @name: a descriptive name of the requesting driver
+ *
+ * This function removes devices that own apertures within @base and @size.
+ *
+ * Returns:
+ * 0 on success, or a negative errno code otherwise
+ */
+int aperture_remove_conflicting_devices(resource_size_t base, resource_size_t size,
+					const char *name)
+{
+	/*
+	 * If a driver asked to unregister a platform device registered by
+	 * sysfb, then can be assumed that this is a driver for a display
+	 * that is set up by the system firmware and has a generic driver.
+	 *
+	 * Drivers for devices that don't have a generic driver will never
+	 * ask for this, so let's assume that a real driver for the display
+	 * was already probed and prevent sysfb to register devices later.
+	 */
+#ifdef __linux__
+	sysfb_disable();
+#endif
+
+	aperture_detach_devices(base, size);
+
+	return 0;
+}
+EXPORT_SYMBOL(aperture_remove_conflicting_devices);
+
+/**
+ * __aperture_remove_legacy_vga_devices - remove legacy VGA devices of a PCI devices
+ * @pdev: PCI device
+ *
+ * This function removes VGA devices provided by @pdev, such as a VGA
+ * framebuffer or a console. This is useful if you have a VGA-compatible
+ * PCI graphics device with framebuffers in non-BAR locations. Drivers
+ * should acquire ownership of those memory areas and afterwards call
+ * this helper to release remaining VGA devices.
+ *
+ * If your hardware has its framebuffers accessible via PCI BARS, use
+ * aperture_remove_conflicting_pci_devices() instead. The function will
+ * release any VGA devices automatically.
+ *
+ * WARNING: Apparently we must remove graphics drivers before calling
+ *          this helper. Otherwise the vga fbdev driver falls over if
+ *          we have vgacon configured.
+ *
+ * Returns:
+ * 0 on success, or a negative errno code otherwise
+ */
+int __aperture_remove_legacy_vga_devices(struct pci_dev *pdev)
+{
+	/* VGA framebuffer */
+	aperture_detach_devices(VGA_FB_PHYS_BASE, VGA_FB_PHYS_SIZE);
+
+	/* VGA textmode console */
+#ifdef __linux__
+	return vga_remove_vgacon(pdev);
+#elif defined(__FreeBSD__)
+	return 0;
+#endif
+}
+EXPORT_SYMBOL(__aperture_remove_legacy_vga_devices);
+
+/**
+ * aperture_remove_conflicting_pci_devices - remove existing framebuffers for PCI devices
+ * @pdev: PCI device
+ * @name: a descriptive name of the requesting driver
+ *
+ * This function removes devices that own apertures within any of @pdev's
+ * memory bars. The function assumes that PCI device with shadowed ROM
+ * drives a primary display and therefore kicks out vga16fb as well.
+ *
+ * Returns:
+ * 0 on success, or a negative errno code otherwise
+ */
+int aperture_remove_conflicting_pci_devices(struct pci_dev *pdev, const char *name)
+{
+	bool primary = false;
+	resource_size_t base, size;
+	int bar, ret = 0;
+
+#ifdef __linux__
+	if (pdev == vga_default_device())
+		primary = true;
+
+	if (primary)
+		sysfb_disable();
+#endif
+
+	for (bar = 0; bar < PCI_STD_NUM_BARS; ++bar) {
+		if (!(pci_resource_flags(pdev, bar) & IORESOURCE_MEM))
+			continue;
+
+		base = pci_resource_start(pdev, bar);
+		size = pci_resource_len(pdev, bar);
+		aperture_detach_devices(base, size);
+	}
+
+	/*
+	 * If this is the primary adapter, there could be a VGA device
+	 * that consumes the VGA framebuffer I/O range. Remove this
+	 * device as well.
+	 */
+	if (primary)
+		ret = __aperture_remove_legacy_vga_devices(pdev);
+
+	return ret;
+
+}
+EXPORT_SYMBOL(aperture_remove_conflicting_pci_devices);

--- a/sys/compat/linuxkpi/common/src/linux_cmdline.c
+++ b/sys/compat/linuxkpi/common/src/linux_cmdline.c
@@ -1,0 +1,63 @@
+/*-
+ * Copyright (c) 2022 Beckhoff Automation GmbH & Co. KG
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ */
+
+#include <sys/param.h>
+#include <sys/systm.h>
+
+#include <video/cmdline.h>
+
+const char *
+video_get_options(const char *connector_name)
+{
+	char tunable[64];
+	const char *options;
+
+	/*
+	 * A user may use loader tunables to set a specific mode for the
+	 * console. Tunables are read in the following order:
+	 *     1. kern.vt.fb.modes.$connector_name
+	 *     2. kern.vt.fb.default_mode
+	 *
+	 * Example of a mode specific to the LVDS connector:
+	 *     kern.vt.fb.modes.LVDS="1024x768"
+	 *
+	 * Example of a mode applied to all connectors not having a
+	 * connector-specific mode:
+	 *     kern.vt.fb.default_mode="640x480"
+	 */
+	snprintf(tunable, sizeof(tunable), "kern.vt.fb.modes.%s",
+	    connector_name);
+	if (bootverbose) {
+		printf("[drm] Connector %s: get mode from tunables:\n", connector_name);
+		printf("[drm]  - %s\n", tunable);
+		printf("[drm]  - kern.vt.fb.default_mode\n");
+	}
+	options = kern_getenv(tunable);
+	if (options == NULL)
+		options = kern_getenv("kern.vt.fb.default_mode");
+
+	return (options);
+}

--- a/sys/compat/linuxkpi/common/src/linux_compat.c
+++ b/sys/compat/linuxkpi/common/src/linux_compat.c
@@ -692,11 +692,11 @@ linux_cdev_pager_populate(vm_object_t vm_obj, vm_pindex_t pidx, int fault_type,
 		vmap->vm_pfn_pcount = &vmap->vm_pfn_count;
 		vmap->vm_obj = vm_obj;
 
-		err = vmap->vm_ops->fault(vmap, &vmf);
+		err = vmap->vm_ops->fault(&vmf);
 
 		while (vmap->vm_pfn_count == 0 && err == VM_FAULT_NOPAGE) {
 			kern_yield(PRI_USER);
-			err = vmap->vm_ops->fault(vmap, &vmf);
+			err = vmap->vm_ops->fault(&vmf);
 		}
 	}
 

--- a/sys/compat/linuxkpi/common/src/linux_devres.c
+++ b/sys/compat/linuxkpi/common/src/linux_devres.c
@@ -222,3 +222,46 @@ lkpi_devm_kmalloc_release(struct device *dev __unused, void *p __unused)
 
 	/* Nothing to do.  Freed with the devres. */
 }
+
+struct devres_action {
+	void *data;
+	void (*action)(void *);
+};
+
+static void
+lkpi_devm_action_release(struct device *dev, void *res)
+{
+	struct devres_action	*devres;
+
+	devres = (struct devres_action *)res;
+	devres->action(devres->data);
+}
+
+int
+lkpi_devm_add_action(struct device *dev, void (*action)(void *), void *data)
+{
+	struct devres_action *devres;
+
+	KASSERT(action != NULL, ("%s: action is NULL\n", __func__));
+	devres = lkpi_devres_alloc(lkpi_devm_action_release,
+		sizeof(struct devres_action), GFP_KERNEL);
+	if (devres == NULL)
+		return (-ENOMEM);
+	devres->data = data;
+	devres->action = action;
+	devres_add(dev, devres);
+
+	return (0);
+}
+
+int
+lkpi_devm_add_action_or_reset(struct device *dev, void (*action)(void *), void *data)
+{
+	int rv;
+
+	rv = lkpi_devm_add_action(dev, action, data);
+	if (rv != 0)
+		action(data);
+
+	return (rv);
+}

--- a/sys/compat/linuxkpi/common/src/linux_hdmi.c
+++ b/sys/compat/linuxkpi/common/src/linux_hdmi.c
@@ -1,0 +1,1959 @@
+/*
+ * Copyright (C) 2012 Avionic Design GmbH
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sub license,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the
+ * next paragraph) shall be included in all copies or substantial portions
+ * of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#ifdef __linux__
+#include <drm/display/drm_dp.h>
+#endif
+#include <linux/bitops.h>
+#include <linux/bug.h>
+#include <linux/errno.h>
+#include <linux/export.h>
+#include <linux/hdmi.h>
+#include <linux/string.h>
+#include <linux/device.h>
+
+#define hdmi_log(fmt, ...) dev_printk(level, dev, fmt, ##__VA_ARGS__)
+
+static u8 hdmi_infoframe_checksum(const u8 *ptr, size_t size)
+{
+	u8 csum = 0;
+	size_t i;
+
+	/* compute checksum */
+	for (i = 0; i < size; i++)
+		csum += ptr[i];
+
+	return 256 - csum;
+}
+
+static void hdmi_infoframe_set_checksum(void *buffer, size_t size)
+{
+	u8 *ptr = buffer;
+
+	ptr[3] = hdmi_infoframe_checksum(buffer, size);
+}
+
+/**
+ * hdmi_avi_infoframe_init() - initialize an HDMI AVI infoframe
+ * @frame: HDMI AVI infoframe
+ */
+void hdmi_avi_infoframe_init(struct hdmi_avi_infoframe *frame)
+{
+	memset(frame, 0, sizeof(*frame));
+
+	frame->type = HDMI_INFOFRAME_TYPE_AVI;
+	frame->version = 2;
+	frame->length = HDMI_AVI_INFOFRAME_SIZE;
+}
+EXPORT_SYMBOL(hdmi_avi_infoframe_init);
+
+static int hdmi_avi_infoframe_check_only(const struct hdmi_avi_infoframe *frame)
+{
+	if (frame->type != HDMI_INFOFRAME_TYPE_AVI ||
+	    frame->version != 2 ||
+	    frame->length != HDMI_AVI_INFOFRAME_SIZE)
+		return -EINVAL;
+
+	if (frame->picture_aspect > HDMI_PICTURE_ASPECT_16_9)
+		return -EINVAL;
+
+	return 0;
+}
+
+/**
+ * hdmi_avi_infoframe_check() - check a HDMI AVI infoframe
+ * @frame: HDMI AVI infoframe
+ *
+ * Validates that the infoframe is consistent and updates derived fields
+ * (eg. length) based on other fields.
+ *
+ * Returns 0 on success or a negative error code on failure.
+ */
+int hdmi_avi_infoframe_check(struct hdmi_avi_infoframe *frame)
+{
+	return hdmi_avi_infoframe_check_only(frame);
+}
+EXPORT_SYMBOL(hdmi_avi_infoframe_check);
+
+/**
+ * hdmi_avi_infoframe_pack_only() - write HDMI AVI infoframe to binary buffer
+ * @frame: HDMI AVI infoframe
+ * @buffer: destination buffer
+ * @size: size of buffer
+ *
+ * Packs the information contained in the @frame structure into a binary
+ * representation that can be written into the corresponding controller
+ * registers. Also computes the checksum as required by section 5.3.5 of
+ * the HDMI 1.4 specification.
+ *
+ * Returns the number of bytes packed into the binary buffer or a negative
+ * error code on failure.
+ */
+ssize_t hdmi_avi_infoframe_pack_only(const struct hdmi_avi_infoframe *frame,
+				     void *buffer, size_t size)
+{
+	u8 *ptr = buffer;
+	size_t length;
+	int ret;
+
+	ret = hdmi_avi_infoframe_check_only(frame);
+	if (ret)
+		return ret;
+
+	length = HDMI_INFOFRAME_HEADER_SIZE + frame->length;
+
+	if (size < length)
+		return -ENOSPC;
+
+	memset(buffer, 0, size);
+
+	ptr[0] = frame->type;
+	ptr[1] = frame->version;
+	ptr[2] = frame->length;
+	ptr[3] = 0; /* checksum */
+
+	/* start infoframe payload */
+	ptr += HDMI_INFOFRAME_HEADER_SIZE;
+
+	ptr[0] = ((frame->colorspace & 0x3) << 5) | (frame->scan_mode & 0x3);
+
+	/*
+	 * Data byte 1, bit 4 has to be set if we provide the active format
+	 * aspect ratio
+	 */
+	if (frame->active_aspect & 0xf)
+		ptr[0] |= BIT(4);
+
+	/* Bit 3 and 2 indicate if we transmit horizontal/vertical bar data */
+	if (frame->top_bar || frame->bottom_bar)
+		ptr[0] |= BIT(3);
+
+	if (frame->left_bar || frame->right_bar)
+		ptr[0] |= BIT(2);
+
+	ptr[1] = ((frame->colorimetry & 0x3) << 6) |
+		 ((frame->picture_aspect & 0x3) << 4) |
+		 (frame->active_aspect & 0xf);
+
+	ptr[2] = ((frame->extended_colorimetry & 0x7) << 4) |
+		 ((frame->quantization_range & 0x3) << 2) |
+		 (frame->nups & 0x3);
+
+	if (frame->itc)
+		ptr[2] |= BIT(7);
+
+	ptr[3] = frame->video_code & 0x7f;
+
+	ptr[4] = ((frame->ycc_quantization_range & 0x3) << 6) |
+		 ((frame->content_type & 0x3) << 4) |
+		 (frame->pixel_repeat & 0xf);
+
+	ptr[5] = frame->top_bar & 0xff;
+	ptr[6] = (frame->top_bar >> 8) & 0xff;
+	ptr[7] = frame->bottom_bar & 0xff;
+	ptr[8] = (frame->bottom_bar >> 8) & 0xff;
+	ptr[9] = frame->left_bar & 0xff;
+	ptr[10] = (frame->left_bar >> 8) & 0xff;
+	ptr[11] = frame->right_bar & 0xff;
+	ptr[12] = (frame->right_bar >> 8) & 0xff;
+
+	hdmi_infoframe_set_checksum(buffer, length);
+
+	return length;
+}
+EXPORT_SYMBOL(hdmi_avi_infoframe_pack_only);
+
+/**
+ * hdmi_avi_infoframe_pack() - check a HDMI AVI infoframe,
+ *                             and write it to binary buffer
+ * @frame: HDMI AVI infoframe
+ * @buffer: destination buffer
+ * @size: size of buffer
+ *
+ * Validates that the infoframe is consistent and updates derived fields
+ * (eg. length) based on other fields, after which it packs the information
+ * contained in the @frame structure into a binary representation that
+ * can be written into the corresponding controller registers. This function
+ * also computes the checksum as required by section 5.3.5 of the HDMI 1.4
+ * specification.
+ *
+ * Returns the number of bytes packed into the binary buffer or a negative
+ * error code on failure.
+ */
+ssize_t hdmi_avi_infoframe_pack(struct hdmi_avi_infoframe *frame,
+				void *buffer, size_t size)
+{
+	int ret;
+
+	ret = hdmi_avi_infoframe_check(frame);
+	if (ret)
+		return ret;
+
+	return hdmi_avi_infoframe_pack_only(frame, buffer, size);
+}
+EXPORT_SYMBOL(hdmi_avi_infoframe_pack);
+
+/**
+ * hdmi_spd_infoframe_init() - initialize an HDMI SPD infoframe
+ * @frame: HDMI SPD infoframe
+ * @vendor: vendor string
+ * @product: product string
+ *
+ * Returns 0 on success or a negative error code on failure.
+ */
+int hdmi_spd_infoframe_init(struct hdmi_spd_infoframe *frame,
+			    const char *vendor, const char *product)
+{
+	size_t len;
+
+	memset(frame, 0, sizeof(*frame));
+
+	frame->type = HDMI_INFOFRAME_TYPE_SPD;
+	frame->version = 1;
+	frame->length = HDMI_SPD_INFOFRAME_SIZE;
+
+	len = strlen(vendor);
+	memcpy(frame->vendor, vendor, min(len, sizeof(frame->vendor)));
+	len = strlen(product);
+	memcpy(frame->product, product, min(len, sizeof(frame->product)));
+
+	return 0;
+}
+EXPORT_SYMBOL(hdmi_spd_infoframe_init);
+
+static int hdmi_spd_infoframe_check_only(const struct hdmi_spd_infoframe *frame)
+{
+	if (frame->type != HDMI_INFOFRAME_TYPE_SPD ||
+	    frame->version != 1 ||
+	    frame->length != HDMI_SPD_INFOFRAME_SIZE)
+		return -EINVAL;
+
+	return 0;
+}
+
+/**
+ * hdmi_spd_infoframe_check() - check a HDMI SPD infoframe
+ * @frame: HDMI SPD infoframe
+ *
+ * Validates that the infoframe is consistent and updates derived fields
+ * (eg. length) based on other fields.
+ *
+ * Returns 0 on success or a negative error code on failure.
+ */
+int hdmi_spd_infoframe_check(struct hdmi_spd_infoframe *frame)
+{
+	return hdmi_spd_infoframe_check_only(frame);
+}
+EXPORT_SYMBOL(hdmi_spd_infoframe_check);
+
+/**
+ * hdmi_spd_infoframe_pack_only() - write HDMI SPD infoframe to binary buffer
+ * @frame: HDMI SPD infoframe
+ * @buffer: destination buffer
+ * @size: size of buffer
+ *
+ * Packs the information contained in the @frame structure into a binary
+ * representation that can be written into the corresponding controller
+ * registers. Also computes the checksum as required by section 5.3.5 of
+ * the HDMI 1.4 specification.
+ *
+ * Returns the number of bytes packed into the binary buffer or a negative
+ * error code on failure.
+ */
+ssize_t hdmi_spd_infoframe_pack_only(const struct hdmi_spd_infoframe *frame,
+				     void *buffer, size_t size)
+{
+	u8 *ptr = buffer;
+	size_t length;
+	int ret;
+
+	ret = hdmi_spd_infoframe_check_only(frame);
+	if (ret)
+		return ret;
+
+	length = HDMI_INFOFRAME_HEADER_SIZE + frame->length;
+
+	if (size < length)
+		return -ENOSPC;
+
+	memset(buffer, 0, size);
+
+	ptr[0] = frame->type;
+	ptr[1] = frame->version;
+	ptr[2] = frame->length;
+	ptr[3] = 0; /* checksum */
+
+	/* start infoframe payload */
+	ptr += HDMI_INFOFRAME_HEADER_SIZE;
+
+	memcpy(ptr, frame->vendor, sizeof(frame->vendor));
+	memcpy(ptr + 8, frame->product, sizeof(frame->product));
+
+	ptr[24] = frame->sdi;
+
+	hdmi_infoframe_set_checksum(buffer, length);
+
+	return length;
+}
+EXPORT_SYMBOL(hdmi_spd_infoframe_pack_only);
+
+/**
+ * hdmi_spd_infoframe_pack() - check a HDMI SPD infoframe,
+ *                             and write it to binary buffer
+ * @frame: HDMI SPD infoframe
+ * @buffer: destination buffer
+ * @size: size of buffer
+ *
+ * Validates that the infoframe is consistent and updates derived fields
+ * (eg. length) based on other fields, after which it packs the information
+ * contained in the @frame structure into a binary representation that
+ * can be written into the corresponding controller registers. This function
+ * also computes the checksum as required by section 5.3.5 of the HDMI 1.4
+ * specification.
+ *
+ * Returns the number of bytes packed into the binary buffer or a negative
+ * error code on failure.
+ */
+ssize_t hdmi_spd_infoframe_pack(struct hdmi_spd_infoframe *frame,
+				void *buffer, size_t size)
+{
+	int ret;
+
+	ret = hdmi_spd_infoframe_check(frame);
+	if (ret)
+		return ret;
+
+	return hdmi_spd_infoframe_pack_only(frame, buffer, size);
+}
+EXPORT_SYMBOL(hdmi_spd_infoframe_pack);
+
+/**
+ * hdmi_audio_infoframe_init() - initialize an HDMI audio infoframe
+ * @frame: HDMI audio infoframe
+ *
+ * Returns 0 on success or a negative error code on failure.
+ */
+int hdmi_audio_infoframe_init(struct hdmi_audio_infoframe *frame)
+{
+	memset(frame, 0, sizeof(*frame));
+
+	frame->type = HDMI_INFOFRAME_TYPE_AUDIO;
+	frame->version = 1;
+	frame->length = HDMI_AUDIO_INFOFRAME_SIZE;
+
+	return 0;
+}
+EXPORT_SYMBOL(hdmi_audio_infoframe_init);
+
+static int hdmi_audio_infoframe_check_only(const struct hdmi_audio_infoframe *frame)
+{
+	if (frame->type != HDMI_INFOFRAME_TYPE_AUDIO ||
+	    frame->version != 1 ||
+	    frame->length != HDMI_AUDIO_INFOFRAME_SIZE)
+		return -EINVAL;
+
+	return 0;
+}
+
+/**
+ * hdmi_audio_infoframe_check() - check a HDMI audio infoframe
+ * @frame: HDMI audio infoframe
+ *
+ * Validates that the infoframe is consistent and updates derived fields
+ * (eg. length) based on other fields.
+ *
+ * Returns 0 on success or a negative error code on failure.
+ */
+int hdmi_audio_infoframe_check(const struct hdmi_audio_infoframe *frame)
+{
+	return hdmi_audio_infoframe_check_only(frame);
+}
+EXPORT_SYMBOL(hdmi_audio_infoframe_check);
+
+static void
+hdmi_audio_infoframe_pack_payload(const struct hdmi_audio_infoframe *frame,
+				  u8 *buffer)
+{
+	u8 channels;
+
+	if (frame->channels >= 2)
+		channels = frame->channels - 1;
+	else
+		channels = 0;
+
+	buffer[0] = ((frame->coding_type & 0xf) << 4) | (channels & 0x7);
+	buffer[1] = ((frame->sample_frequency & 0x7) << 2) |
+		 (frame->sample_size & 0x3);
+	buffer[2] = frame->coding_type_ext & 0x1f;
+	buffer[3] = frame->channel_allocation;
+	buffer[4] = (frame->level_shift_value & 0xf) << 3;
+
+	if (frame->downmix_inhibit)
+		buffer[4] |= BIT(7);
+}
+
+/**
+ * hdmi_audio_infoframe_pack_only() - write HDMI audio infoframe to binary buffer
+ * @frame: HDMI audio infoframe
+ * @buffer: destination buffer
+ * @size: size of buffer
+ *
+ * Packs the information contained in the @frame structure into a binary
+ * representation that can be written into the corresponding controller
+ * registers. Also computes the checksum as required by section 5.3.5 of
+ * the HDMI 1.4 specification.
+ *
+ * Returns the number of bytes packed into the binary buffer or a negative
+ * error code on failure.
+ */
+ssize_t hdmi_audio_infoframe_pack_only(const struct hdmi_audio_infoframe *frame,
+				       void *buffer, size_t size)
+{
+	u8 *ptr = buffer;
+	size_t length;
+	int ret;
+
+	ret = hdmi_audio_infoframe_check_only(frame);
+	if (ret)
+		return ret;
+
+	length = HDMI_INFOFRAME_HEADER_SIZE + frame->length;
+
+	if (size < length)
+		return -ENOSPC;
+
+	memset(buffer, 0, size);
+
+	ptr[0] = frame->type;
+	ptr[1] = frame->version;
+	ptr[2] = frame->length;
+	ptr[3] = 0; /* checksum */
+
+	hdmi_audio_infoframe_pack_payload(frame,
+					  ptr + HDMI_INFOFRAME_HEADER_SIZE);
+
+	hdmi_infoframe_set_checksum(buffer, length);
+
+	return length;
+}
+EXPORT_SYMBOL(hdmi_audio_infoframe_pack_only);
+
+/**
+ * hdmi_audio_infoframe_pack() - check a HDMI Audio infoframe,
+ *                               and write it to binary buffer
+ * @frame: HDMI Audio infoframe
+ * @buffer: destination buffer
+ * @size: size of buffer
+ *
+ * Validates that the infoframe is consistent and updates derived fields
+ * (eg. length) based on other fields, after which it packs the information
+ * contained in the @frame structure into a binary representation that
+ * can be written into the corresponding controller registers. This function
+ * also computes the checksum as required by section 5.3.5 of the HDMI 1.4
+ * specification.
+ *
+ * Returns the number of bytes packed into the binary buffer or a negative
+ * error code on failure.
+ */
+ssize_t hdmi_audio_infoframe_pack(struct hdmi_audio_infoframe *frame,
+				  void *buffer, size_t size)
+{
+	int ret;
+
+	ret = hdmi_audio_infoframe_check(frame);
+	if (ret)
+		return ret;
+
+	return hdmi_audio_infoframe_pack_only(frame, buffer, size);
+}
+EXPORT_SYMBOL(hdmi_audio_infoframe_pack);
+
+#ifdef __linux__
+/**
+ * hdmi_audio_infoframe_pack_for_dp - Pack a HDMI Audio infoframe for DisplayPort
+ *
+ * @frame:      HDMI Audio infoframe
+ * @sdp:        Secondary data packet for DisplayPort.
+ * @dp_version: DisplayPort version to be encoded in the header
+ *
+ * Packs a HDMI Audio Infoframe to be sent over DisplayPort. This function
+ * fills the secondary data packet to be used for DisplayPort.
+ *
+ * Return: Number of total written bytes or a negative errno on failure.
+ */
+ssize_t
+hdmi_audio_infoframe_pack_for_dp(const struct hdmi_audio_infoframe *frame,
+				 struct dp_sdp *sdp, u8 dp_version)
+{
+	int ret;
+
+	ret = hdmi_audio_infoframe_check(frame);
+	if (ret)
+		return ret;
+
+	memset(sdp->db, 0, sizeof(sdp->db));
+
+	/* Secondary-data packet header */
+	sdp->sdp_header.HB0 = 0;
+	sdp->sdp_header.HB1 = frame->type;
+	sdp->sdp_header.HB2 = DP_SDP_AUDIO_INFOFRAME_HB2;
+	sdp->sdp_header.HB3 = (dp_version & 0x3f) << 2;
+
+	hdmi_audio_infoframe_pack_payload(frame, sdp->db);
+
+	/* Return size =  frame length + four HB for sdp_header */
+	return frame->length + 4;
+}
+EXPORT_SYMBOL(hdmi_audio_infoframe_pack_for_dp);
+#endif
+
+/**
+ * hdmi_vendor_infoframe_init() - initialize an HDMI vendor infoframe
+ * @frame: HDMI vendor infoframe
+ *
+ * Returns 0 on success or a negative error code on failure.
+ */
+int hdmi_vendor_infoframe_init(struct hdmi_vendor_infoframe *frame)
+{
+	memset(frame, 0, sizeof(*frame));
+
+	frame->type = HDMI_INFOFRAME_TYPE_VENDOR;
+	frame->version = 1;
+
+	frame->oui = HDMI_IEEE_OUI;
+
+	/*
+	 * 0 is a valid value for s3d_struct, so we use a special "not set"
+	 * value
+	 */
+	frame->s3d_struct = HDMI_3D_STRUCTURE_INVALID;
+	frame->length = HDMI_VENDOR_INFOFRAME_SIZE;
+
+	return 0;
+}
+EXPORT_SYMBOL(hdmi_vendor_infoframe_init);
+
+static int hdmi_vendor_infoframe_length(const struct hdmi_vendor_infoframe *frame)
+{
+	/* for side by side (half) we also need to provide 3D_Ext_Data */
+	if (frame->s3d_struct >= HDMI_3D_STRUCTURE_SIDE_BY_SIDE_HALF)
+		return 6;
+	else if (frame->vic != 0 || frame->s3d_struct != HDMI_3D_STRUCTURE_INVALID)
+		return 5;
+	else
+		return 4;
+}
+
+static int hdmi_vendor_infoframe_check_only(const struct hdmi_vendor_infoframe *frame)
+{
+	if (frame->type != HDMI_INFOFRAME_TYPE_VENDOR ||
+	    frame->version != 1 ||
+	    frame->oui != HDMI_IEEE_OUI)
+		return -EINVAL;
+
+	/* only one of those can be supplied */
+	if (frame->vic != 0 && frame->s3d_struct != HDMI_3D_STRUCTURE_INVALID)
+		return -EINVAL;
+
+	if (frame->length != hdmi_vendor_infoframe_length(frame))
+		return -EINVAL;
+
+	return 0;
+}
+
+/**
+ * hdmi_vendor_infoframe_check() - check a HDMI vendor infoframe
+ * @frame: HDMI infoframe
+ *
+ * Validates that the infoframe is consistent and updates derived fields
+ * (eg. length) based on other fields.
+ *
+ * Returns 0 on success or a negative error code on failure.
+ */
+int hdmi_vendor_infoframe_check(struct hdmi_vendor_infoframe *frame)
+{
+	frame->length = hdmi_vendor_infoframe_length(frame);
+
+	return hdmi_vendor_infoframe_check_only(frame);
+}
+EXPORT_SYMBOL(hdmi_vendor_infoframe_check);
+
+/**
+ * hdmi_vendor_infoframe_pack_only() - write a HDMI vendor infoframe to binary buffer
+ * @frame: HDMI infoframe
+ * @buffer: destination buffer
+ * @size: size of buffer
+ *
+ * Packs the information contained in the @frame structure into a binary
+ * representation that can be written into the corresponding controller
+ * registers. Also computes the checksum as required by section 5.3.5 of
+ * the HDMI 1.4 specification.
+ *
+ * Returns the number of bytes packed into the binary buffer or a negative
+ * error code on failure.
+ */
+ssize_t hdmi_vendor_infoframe_pack_only(const struct hdmi_vendor_infoframe *frame,
+					void *buffer, size_t size)
+{
+	u8 *ptr = buffer;
+	size_t length;
+	int ret;
+
+	ret = hdmi_vendor_infoframe_check_only(frame);
+	if (ret)
+		return ret;
+
+	length = HDMI_INFOFRAME_HEADER_SIZE + frame->length;
+
+	if (size < length)
+		return -ENOSPC;
+
+	memset(buffer, 0, size);
+
+	ptr[0] = frame->type;
+	ptr[1] = frame->version;
+	ptr[2] = frame->length;
+	ptr[3] = 0; /* checksum */
+
+	/* HDMI OUI */
+	ptr[4] = 0x03;
+	ptr[5] = 0x0c;
+	ptr[6] = 0x00;
+
+	if (frame->s3d_struct != HDMI_3D_STRUCTURE_INVALID) {
+		ptr[7] = 0x2 << 5;	/* video format */
+		ptr[8] = (frame->s3d_struct & 0xf) << 4;
+		if (frame->s3d_struct >= HDMI_3D_STRUCTURE_SIDE_BY_SIDE_HALF)
+			ptr[9] = (frame->s3d_ext_data & 0xf) << 4;
+	} else if (frame->vic) {
+		ptr[7] = 0x1 << 5;	/* video format */
+		ptr[8] = frame->vic;
+	} else {
+		ptr[7] = 0x0 << 5;	/* video format */
+	}
+
+	hdmi_infoframe_set_checksum(buffer, length);
+
+	return length;
+}
+EXPORT_SYMBOL(hdmi_vendor_infoframe_pack_only);
+
+/**
+ * hdmi_vendor_infoframe_pack() - check a HDMI Vendor infoframe,
+ *                                and write it to binary buffer
+ * @frame: HDMI Vendor infoframe
+ * @buffer: destination buffer
+ * @size: size of buffer
+ *
+ * Validates that the infoframe is consistent and updates derived fields
+ * (eg. length) based on other fields, after which it packs the information
+ * contained in the @frame structure into a binary representation that
+ * can be written into the corresponding controller registers. This function
+ * also computes the checksum as required by section 5.3.5 of the HDMI 1.4
+ * specification.
+ *
+ * Returns the number of bytes packed into the binary buffer or a negative
+ * error code on failure.
+ */
+ssize_t hdmi_vendor_infoframe_pack(struct hdmi_vendor_infoframe *frame,
+				   void *buffer, size_t size)
+{
+	int ret;
+
+	ret = hdmi_vendor_infoframe_check(frame);
+	if (ret)
+		return ret;
+
+	return hdmi_vendor_infoframe_pack_only(frame, buffer, size);
+}
+EXPORT_SYMBOL(hdmi_vendor_infoframe_pack);
+
+static int
+hdmi_vendor_any_infoframe_check_only(const union hdmi_vendor_any_infoframe *frame)
+{
+	if (frame->any.type != HDMI_INFOFRAME_TYPE_VENDOR ||
+	    frame->any.version != 1)
+		return -EINVAL;
+
+	return 0;
+}
+
+/**
+ * hdmi_drm_infoframe_init() - initialize an HDMI Dynaminc Range and
+ * mastering infoframe
+ * @frame: HDMI DRM infoframe
+ *
+ * Returns 0 on success or a negative error code on failure.
+ */
+int hdmi_drm_infoframe_init(struct hdmi_drm_infoframe *frame)
+{
+	memset(frame, 0, sizeof(*frame));
+
+	frame->type = HDMI_INFOFRAME_TYPE_DRM;
+	frame->version = 1;
+	frame->length = HDMI_DRM_INFOFRAME_SIZE;
+
+	return 0;
+}
+EXPORT_SYMBOL(hdmi_drm_infoframe_init);
+
+static int hdmi_drm_infoframe_check_only(const struct hdmi_drm_infoframe *frame)
+{
+	if (frame->type != HDMI_INFOFRAME_TYPE_DRM ||
+	    frame->version != 1)
+		return -EINVAL;
+
+	if (frame->length != HDMI_DRM_INFOFRAME_SIZE)
+		return -EINVAL;
+
+	return 0;
+}
+
+/**
+ * hdmi_drm_infoframe_check() - check a HDMI DRM infoframe
+ * @frame: HDMI DRM infoframe
+ *
+ * Validates that the infoframe is consistent.
+ * Returns 0 on success or a negative error code on failure.
+ */
+int hdmi_drm_infoframe_check(struct hdmi_drm_infoframe *frame)
+{
+	return hdmi_drm_infoframe_check_only(frame);
+}
+EXPORT_SYMBOL(hdmi_drm_infoframe_check);
+
+/**
+ * hdmi_drm_infoframe_pack_only() - write HDMI DRM infoframe to binary buffer
+ * @frame: HDMI DRM infoframe
+ * @buffer: destination buffer
+ * @size: size of buffer
+ *
+ * Packs the information contained in the @frame structure into a binary
+ * representation that can be written into the corresponding controller
+ * registers. Also computes the checksum as required by section 5.3.5 of
+ * the HDMI 1.4 specification.
+ *
+ * Returns the number of bytes packed into the binary buffer or a negative
+ * error code on failure.
+ */
+ssize_t hdmi_drm_infoframe_pack_only(const struct hdmi_drm_infoframe *frame,
+				     void *buffer, size_t size)
+{
+	u8 *ptr = buffer;
+	size_t length;
+	int i;
+
+	length = HDMI_INFOFRAME_HEADER_SIZE + frame->length;
+
+	if (size < length)
+		return -ENOSPC;
+
+	memset(buffer, 0, size);
+
+	ptr[0] = frame->type;
+	ptr[1] = frame->version;
+	ptr[2] = frame->length;
+	ptr[3] = 0; /* checksum */
+
+	/* start infoframe payload */
+	ptr += HDMI_INFOFRAME_HEADER_SIZE;
+
+	*ptr++ = frame->eotf;
+	*ptr++ = frame->metadata_type;
+
+	for (i = 0; i < 3; i++) {
+		*ptr++ = frame->display_primaries[i].x;
+		*ptr++ = frame->display_primaries[i].x >> 8;
+		*ptr++ = frame->display_primaries[i].y;
+		*ptr++ = frame->display_primaries[i].y >> 8;
+	}
+
+	*ptr++ = frame->white_point.x;
+	*ptr++ = frame->white_point.x >> 8;
+
+	*ptr++ = frame->white_point.y;
+	*ptr++ = frame->white_point.y >> 8;
+
+	*ptr++ = frame->max_display_mastering_luminance;
+	*ptr++ = frame->max_display_mastering_luminance >> 8;
+
+	*ptr++ = frame->min_display_mastering_luminance;
+	*ptr++ = frame->min_display_mastering_luminance >> 8;
+
+	*ptr++ = frame->max_cll;
+	*ptr++ = frame->max_cll >> 8;
+
+	*ptr++ = frame->max_fall;
+	*ptr++ = frame->max_fall >> 8;
+
+	hdmi_infoframe_set_checksum(buffer, length);
+
+	return length;
+}
+EXPORT_SYMBOL(hdmi_drm_infoframe_pack_only);
+
+/**
+ * hdmi_drm_infoframe_pack() - check a HDMI DRM infoframe,
+ *                             and write it to binary buffer
+ * @frame: HDMI DRM infoframe
+ * @buffer: destination buffer
+ * @size: size of buffer
+ *
+ * Validates that the infoframe is consistent and updates derived fields
+ * (eg. length) based on other fields, after which it packs the information
+ * contained in the @frame structure into a binary representation that
+ * can be written into the corresponding controller registers. This function
+ * also computes the checksum as required by section 5.3.5 of the HDMI 1.4
+ * specification.
+ *
+ * Returns the number of bytes packed into the binary buffer or a negative
+ * error code on failure.
+ */
+ssize_t hdmi_drm_infoframe_pack(struct hdmi_drm_infoframe *frame,
+				void *buffer, size_t size)
+{
+	int ret;
+
+	ret = hdmi_drm_infoframe_check(frame);
+	if (ret)
+		return ret;
+
+	return hdmi_drm_infoframe_pack_only(frame, buffer, size);
+}
+EXPORT_SYMBOL(hdmi_drm_infoframe_pack);
+
+/*
+ * hdmi_vendor_any_infoframe_check() - check a vendor infoframe
+ */
+static int
+hdmi_vendor_any_infoframe_check(union hdmi_vendor_any_infoframe *frame)
+{
+	int ret;
+
+	ret = hdmi_vendor_any_infoframe_check_only(frame);
+	if (ret)
+		return ret;
+
+	/* we only know about HDMI vendor infoframes */
+	if (frame->any.oui != HDMI_IEEE_OUI)
+		return -EINVAL;
+
+	return hdmi_vendor_infoframe_check(&frame->hdmi);
+}
+
+/*
+ * hdmi_vendor_any_infoframe_pack_only() - write a vendor infoframe to binary buffer
+ */
+static ssize_t
+hdmi_vendor_any_infoframe_pack_only(const union hdmi_vendor_any_infoframe *frame,
+				    void *buffer, size_t size)
+{
+	int ret;
+
+	ret = hdmi_vendor_any_infoframe_check_only(frame);
+	if (ret)
+		return ret;
+
+	/* we only know about HDMI vendor infoframes */
+	if (frame->any.oui != HDMI_IEEE_OUI)
+		return -EINVAL;
+
+	return hdmi_vendor_infoframe_pack_only(&frame->hdmi, buffer, size);
+}
+
+/*
+ * hdmi_vendor_any_infoframe_pack() - check a vendor infoframe,
+ *                                    and write it to binary buffer
+ */
+static ssize_t
+hdmi_vendor_any_infoframe_pack(union hdmi_vendor_any_infoframe *frame,
+			       void *buffer, size_t size)
+{
+	int ret;
+
+	ret = hdmi_vendor_any_infoframe_check(frame);
+	if (ret)
+		return ret;
+
+	return hdmi_vendor_any_infoframe_pack_only(frame, buffer, size);
+}
+
+/**
+ * hdmi_infoframe_check() - check a HDMI infoframe
+ * @frame: HDMI infoframe
+ *
+ * Validates that the infoframe is consistent and updates derived fields
+ * (eg. length) based on other fields.
+ *
+ * Returns 0 on success or a negative error code on failure.
+ */
+int
+hdmi_infoframe_check(union hdmi_infoframe *frame)
+{
+	switch (frame->any.type) {
+	case HDMI_INFOFRAME_TYPE_AVI:
+		return hdmi_avi_infoframe_check(&frame->avi);
+	case HDMI_INFOFRAME_TYPE_SPD:
+		return hdmi_spd_infoframe_check(&frame->spd);
+	case HDMI_INFOFRAME_TYPE_AUDIO:
+		return hdmi_audio_infoframe_check(&frame->audio);
+	case HDMI_INFOFRAME_TYPE_VENDOR:
+		return hdmi_vendor_any_infoframe_check(&frame->vendor);
+	default:
+		WARN(1, "Bad infoframe type %d\n", frame->any.type);
+		return -EINVAL;
+	}
+}
+EXPORT_SYMBOL(hdmi_infoframe_check);
+
+/**
+ * hdmi_infoframe_pack_only() - write a HDMI infoframe to binary buffer
+ * @frame: HDMI infoframe
+ * @buffer: destination buffer
+ * @size: size of buffer
+ *
+ * Packs the information contained in the @frame structure into a binary
+ * representation that can be written into the corresponding controller
+ * registers. Also computes the checksum as required by section 5.3.5 of
+ * the HDMI 1.4 specification.
+ *
+ * Returns the number of bytes packed into the binary buffer or a negative
+ * error code on failure.
+ */
+ssize_t
+hdmi_infoframe_pack_only(const union hdmi_infoframe *frame, void *buffer, size_t size)
+{
+	ssize_t length;
+
+	switch (frame->any.type) {
+	case HDMI_INFOFRAME_TYPE_AVI:
+		length = hdmi_avi_infoframe_pack_only(&frame->avi,
+						      buffer, size);
+		break;
+	case HDMI_INFOFRAME_TYPE_DRM:
+		length = hdmi_drm_infoframe_pack_only(&frame->drm,
+						      buffer, size);
+		break;
+	case HDMI_INFOFRAME_TYPE_SPD:
+		length = hdmi_spd_infoframe_pack_only(&frame->spd,
+						      buffer, size);
+		break;
+	case HDMI_INFOFRAME_TYPE_AUDIO:
+		length = hdmi_audio_infoframe_pack_only(&frame->audio,
+							buffer, size);
+		break;
+	case HDMI_INFOFRAME_TYPE_VENDOR:
+		length = hdmi_vendor_any_infoframe_pack_only(&frame->vendor,
+							     buffer, size);
+		break;
+	default:
+		WARN(1, "Bad infoframe type %d\n", frame->any.type);
+		length = -EINVAL;
+	}
+
+	return length;
+}
+EXPORT_SYMBOL(hdmi_infoframe_pack_only);
+
+/**
+ * hdmi_infoframe_pack() - check a HDMI infoframe,
+ *                         and write it to binary buffer
+ * @frame: HDMI infoframe
+ * @buffer: destination buffer
+ * @size: size of buffer
+ *
+ * Validates that the infoframe is consistent and updates derived fields
+ * (eg. length) based on other fields, after which it packs the information
+ * contained in the @frame structure into a binary representation that
+ * can be written into the corresponding controller registers. This function
+ * also computes the checksum as required by section 5.3.5 of the HDMI 1.4
+ * specification.
+ *
+ * Returns the number of bytes packed into the binary buffer or a negative
+ * error code on failure.
+ */
+ssize_t
+hdmi_infoframe_pack(union hdmi_infoframe *frame,
+		    void *buffer, size_t size)
+{
+	ssize_t length;
+
+	switch (frame->any.type) {
+	case HDMI_INFOFRAME_TYPE_AVI:
+		length = hdmi_avi_infoframe_pack(&frame->avi, buffer, size);
+		break;
+	case HDMI_INFOFRAME_TYPE_DRM:
+		length = hdmi_drm_infoframe_pack(&frame->drm, buffer, size);
+		break;
+	case HDMI_INFOFRAME_TYPE_SPD:
+		length = hdmi_spd_infoframe_pack(&frame->spd, buffer, size);
+		break;
+	case HDMI_INFOFRAME_TYPE_AUDIO:
+		length = hdmi_audio_infoframe_pack(&frame->audio, buffer, size);
+		break;
+	case HDMI_INFOFRAME_TYPE_VENDOR:
+		length = hdmi_vendor_any_infoframe_pack(&frame->vendor,
+							buffer, size);
+		break;
+	default:
+		WARN(1, "Bad infoframe type %d\n", frame->any.type);
+		length = -EINVAL;
+	}
+
+	return length;
+}
+EXPORT_SYMBOL(hdmi_infoframe_pack);
+
+static const char *hdmi_infoframe_type_get_name(enum hdmi_infoframe_type type)
+{
+	if (type < 0x80 || type > 0x9f)
+		return "Invalid";
+	switch (type) {
+	case HDMI_INFOFRAME_TYPE_VENDOR:
+		return "Vendor";
+	case HDMI_INFOFRAME_TYPE_AVI:
+		return "Auxiliary Video Information (AVI)";
+	case HDMI_INFOFRAME_TYPE_SPD:
+		return "Source Product Description (SPD)";
+	case HDMI_INFOFRAME_TYPE_AUDIO:
+		return "Audio";
+	case HDMI_INFOFRAME_TYPE_DRM:
+		return "Dynamic Range and Mastering";
+	}
+	return "Reserved";
+}
+
+static void hdmi_infoframe_log_header(const char *level,
+				      struct device *dev,
+				      const struct hdmi_any_infoframe *frame)
+{
+	hdmi_log("HDMI infoframe: %s, version %u, length %u\n",
+		hdmi_infoframe_type_get_name(frame->type),
+		frame->version, frame->length);
+}
+
+static const char *hdmi_colorspace_get_name(enum hdmi_colorspace colorspace)
+{
+	switch (colorspace) {
+	case HDMI_COLORSPACE_RGB:
+		return "RGB";
+	case HDMI_COLORSPACE_YUV422:
+		return "YCbCr 4:2:2";
+	case HDMI_COLORSPACE_YUV444:
+		return "YCbCr 4:4:4";
+	case HDMI_COLORSPACE_YUV420:
+		return "YCbCr 4:2:0";
+	case HDMI_COLORSPACE_RESERVED4:
+		return "Reserved (4)";
+	case HDMI_COLORSPACE_RESERVED5:
+		return "Reserved (5)";
+	case HDMI_COLORSPACE_RESERVED6:
+		return "Reserved (6)";
+	case HDMI_COLORSPACE_IDO_DEFINED:
+		return "IDO Defined";
+	}
+	return "Invalid";
+}
+
+static const char *hdmi_scan_mode_get_name(enum hdmi_scan_mode scan_mode)
+{
+	switch (scan_mode) {
+	case HDMI_SCAN_MODE_NONE:
+		return "No Data";
+	case HDMI_SCAN_MODE_OVERSCAN:
+		return "Overscan";
+	case HDMI_SCAN_MODE_UNDERSCAN:
+		return "Underscan";
+	case HDMI_SCAN_MODE_RESERVED:
+		return "Reserved";
+	}
+	return "Invalid";
+}
+
+static const char *hdmi_colorimetry_get_name(enum hdmi_colorimetry colorimetry)
+{
+	switch (colorimetry) {
+	case HDMI_COLORIMETRY_NONE:
+		return "No Data";
+	case HDMI_COLORIMETRY_ITU_601:
+		return "ITU601";
+	case HDMI_COLORIMETRY_ITU_709:
+		return "ITU709";
+	case HDMI_COLORIMETRY_EXTENDED:
+		return "Extended";
+	}
+	return "Invalid";
+}
+
+static const char *
+hdmi_picture_aspect_get_name(enum hdmi_picture_aspect picture_aspect)
+{
+	switch (picture_aspect) {
+	case HDMI_PICTURE_ASPECT_NONE:
+		return "No Data";
+	case HDMI_PICTURE_ASPECT_4_3:
+		return "4:3";
+	case HDMI_PICTURE_ASPECT_16_9:
+		return "16:9";
+	case HDMI_PICTURE_ASPECT_64_27:
+		return "64:27";
+	case HDMI_PICTURE_ASPECT_256_135:
+		return "256:135";
+	case HDMI_PICTURE_ASPECT_RESERVED:
+		return "Reserved";
+	}
+	return "Invalid";
+}
+
+static const char *
+hdmi_active_aspect_get_name(enum hdmi_active_aspect active_aspect)
+{
+	if (active_aspect < 0 || active_aspect > 0xf)
+		return "Invalid";
+
+	switch (active_aspect) {
+	case HDMI_ACTIVE_ASPECT_16_9_TOP:
+		return "16:9 Top";
+	case HDMI_ACTIVE_ASPECT_14_9_TOP:
+		return "14:9 Top";
+	case HDMI_ACTIVE_ASPECT_16_9_CENTER:
+		return "16:9 Center";
+	case HDMI_ACTIVE_ASPECT_PICTURE:
+		return "Same as Picture";
+	case HDMI_ACTIVE_ASPECT_4_3:
+		return "4:3";
+	case HDMI_ACTIVE_ASPECT_16_9:
+		return "16:9";
+	case HDMI_ACTIVE_ASPECT_14_9:
+		return "14:9";
+	case HDMI_ACTIVE_ASPECT_4_3_SP_14_9:
+		return "4:3 SP 14:9";
+	case HDMI_ACTIVE_ASPECT_16_9_SP_14_9:
+		return "16:9 SP 14:9";
+	case HDMI_ACTIVE_ASPECT_16_9_SP_4_3:
+		return "16:9 SP 4:3";
+	}
+	return "Reserved";
+}
+
+static const char *
+hdmi_extended_colorimetry_get_name(enum hdmi_extended_colorimetry ext_col)
+{
+	switch (ext_col) {
+	case HDMI_EXTENDED_COLORIMETRY_XV_YCC_601:
+		return "xvYCC 601";
+	case HDMI_EXTENDED_COLORIMETRY_XV_YCC_709:
+		return "xvYCC 709";
+	case HDMI_EXTENDED_COLORIMETRY_S_YCC_601:
+		return "sYCC 601";
+	case HDMI_EXTENDED_COLORIMETRY_OPYCC_601:
+		return "opYCC 601";
+	case HDMI_EXTENDED_COLORIMETRY_OPRGB:
+		return "opRGB";
+	case HDMI_EXTENDED_COLORIMETRY_BT2020_CONST_LUM:
+		return "BT.2020 Constant Luminance";
+	case HDMI_EXTENDED_COLORIMETRY_BT2020:
+		return "BT.2020";
+	case HDMI_EXTENDED_COLORIMETRY_RESERVED:
+		return "Reserved";
+	}
+	return "Invalid";
+}
+
+static const char *
+hdmi_quantization_range_get_name(enum hdmi_quantization_range qrange)
+{
+	switch (qrange) {
+	case HDMI_QUANTIZATION_RANGE_DEFAULT:
+		return "Default";
+	case HDMI_QUANTIZATION_RANGE_LIMITED:
+		return "Limited";
+	case HDMI_QUANTIZATION_RANGE_FULL:
+		return "Full";
+	case HDMI_QUANTIZATION_RANGE_RESERVED:
+		return "Reserved";
+	}
+	return "Invalid";
+}
+
+static const char *hdmi_nups_get_name(enum hdmi_nups nups)
+{
+	switch (nups) {
+	case HDMI_NUPS_UNKNOWN:
+		return "Unknown Non-uniform Scaling";
+	case HDMI_NUPS_HORIZONTAL:
+		return "Horizontally Scaled";
+	case HDMI_NUPS_VERTICAL:
+		return "Vertically Scaled";
+	case HDMI_NUPS_BOTH:
+		return "Horizontally and Vertically Scaled";
+	}
+	return "Invalid";
+}
+
+static const char *
+hdmi_ycc_quantization_range_get_name(enum hdmi_ycc_quantization_range qrange)
+{
+	switch (qrange) {
+	case HDMI_YCC_QUANTIZATION_RANGE_LIMITED:
+		return "Limited";
+	case HDMI_YCC_QUANTIZATION_RANGE_FULL:
+		return "Full";
+	}
+	return "Invalid";
+}
+
+static const char *
+hdmi_content_type_get_name(enum hdmi_content_type content_type)
+{
+	switch (content_type) {
+	case HDMI_CONTENT_TYPE_GRAPHICS:
+		return "Graphics";
+	case HDMI_CONTENT_TYPE_PHOTO:
+		return "Photo";
+	case HDMI_CONTENT_TYPE_CINEMA:
+		return "Cinema";
+	case HDMI_CONTENT_TYPE_GAME:
+		return "Game";
+	}
+	return "Invalid";
+}
+
+static void hdmi_avi_infoframe_log(const char *level,
+				   struct device *dev,
+				   const struct hdmi_avi_infoframe *frame)
+{
+	hdmi_infoframe_log_header(level, dev,
+				  (const struct hdmi_any_infoframe *)frame);
+
+	hdmi_log("    colorspace: %s\n",
+			hdmi_colorspace_get_name(frame->colorspace));
+	hdmi_log("    scan mode: %s\n",
+			hdmi_scan_mode_get_name(frame->scan_mode));
+	hdmi_log("    colorimetry: %s\n",
+			hdmi_colorimetry_get_name(frame->colorimetry));
+	hdmi_log("    picture aspect: %s\n",
+			hdmi_picture_aspect_get_name(frame->picture_aspect));
+	hdmi_log("    active aspect: %s\n",
+			hdmi_active_aspect_get_name(frame->active_aspect));
+	hdmi_log("    itc: %s\n", frame->itc ? "IT Content" : "No Data");
+	hdmi_log("    extended colorimetry: %s\n",
+			hdmi_extended_colorimetry_get_name(frame->extended_colorimetry));
+	hdmi_log("    quantization range: %s\n",
+			hdmi_quantization_range_get_name(frame->quantization_range));
+	hdmi_log("    nups: %s\n", hdmi_nups_get_name(frame->nups));
+	hdmi_log("    video code: %u\n", frame->video_code);
+	hdmi_log("    ycc quantization range: %s\n",
+			hdmi_ycc_quantization_range_get_name(frame->ycc_quantization_range));
+	hdmi_log("    hdmi content type: %s\n",
+			hdmi_content_type_get_name(frame->content_type));
+	hdmi_log("    pixel repeat: %u\n", frame->pixel_repeat);
+	hdmi_log("    bar top %u, bottom %u, left %u, right %u\n",
+			frame->top_bar, frame->bottom_bar,
+			frame->left_bar, frame->right_bar);
+}
+
+static const char *hdmi_spd_sdi_get_name(enum hdmi_spd_sdi sdi)
+{
+	if (sdi < 0 || sdi > 0xff)
+		return "Invalid";
+	switch (sdi) {
+	case HDMI_SPD_SDI_UNKNOWN:
+		return "Unknown";
+	case HDMI_SPD_SDI_DSTB:
+		return "Digital STB";
+	case HDMI_SPD_SDI_DVDP:
+		return "DVD Player";
+	case HDMI_SPD_SDI_DVHS:
+		return "D-VHS";
+	case HDMI_SPD_SDI_HDDVR:
+		return "HDD Videorecorder";
+	case HDMI_SPD_SDI_DVC:
+		return "DVC";
+	case HDMI_SPD_SDI_DSC:
+		return "DSC";
+	case HDMI_SPD_SDI_VCD:
+		return "Video CD";
+	case HDMI_SPD_SDI_GAME:
+		return "Game";
+	case HDMI_SPD_SDI_PC:
+		return "PC General";
+	case HDMI_SPD_SDI_BD:
+		return "Blu-Ray Disc (BD)";
+	case HDMI_SPD_SDI_SACD:
+		return "Super Audio CD";
+	case HDMI_SPD_SDI_HDDVD:
+		return "HD DVD";
+	case HDMI_SPD_SDI_PMP:
+		return "PMP";
+	}
+	return "Reserved";
+}
+
+static void hdmi_spd_infoframe_log(const char *level,
+				   struct device *dev,
+				   const struct hdmi_spd_infoframe *frame)
+{
+	u8 buf[17];
+
+	hdmi_infoframe_log_header(level, dev,
+				  (const struct hdmi_any_infoframe *)frame);
+
+	memset(buf, 0, sizeof(buf));
+
+	strncpy(buf, frame->vendor, 8);
+	hdmi_log("    vendor: %s\n", buf);
+	strncpy(buf, frame->product, 16);
+	hdmi_log("    product: %s\n", buf);
+	hdmi_log("    source device information: %s (0x%x)\n",
+		hdmi_spd_sdi_get_name(frame->sdi), frame->sdi);
+}
+
+static const char *
+hdmi_audio_coding_type_get_name(enum hdmi_audio_coding_type coding_type)
+{
+	switch (coding_type) {
+	case HDMI_AUDIO_CODING_TYPE_STREAM:
+		return "Refer to Stream Header";
+	case HDMI_AUDIO_CODING_TYPE_PCM:
+		return "PCM";
+	case HDMI_AUDIO_CODING_TYPE_AC3:
+		return "AC-3";
+	case HDMI_AUDIO_CODING_TYPE_MPEG1:
+		return "MPEG1";
+	case HDMI_AUDIO_CODING_TYPE_MP3:
+		return "MP3";
+	case HDMI_AUDIO_CODING_TYPE_MPEG2:
+		return "MPEG2";
+	case HDMI_AUDIO_CODING_TYPE_AAC_LC:
+		return "AAC";
+	case HDMI_AUDIO_CODING_TYPE_DTS:
+		return "DTS";
+	case HDMI_AUDIO_CODING_TYPE_ATRAC:
+		return "ATRAC";
+	case HDMI_AUDIO_CODING_TYPE_DSD:
+		return "One Bit Audio";
+	case HDMI_AUDIO_CODING_TYPE_EAC3:
+		return "Dolby Digital +";
+	case HDMI_AUDIO_CODING_TYPE_DTS_HD:
+		return "DTS-HD";
+	case HDMI_AUDIO_CODING_TYPE_MLP:
+		return "MAT (MLP)";
+	case HDMI_AUDIO_CODING_TYPE_DST:
+		return "DST";
+	case HDMI_AUDIO_CODING_TYPE_WMA_PRO:
+		return "WMA PRO";
+	case HDMI_AUDIO_CODING_TYPE_CXT:
+		return "Refer to CXT";
+	}
+	return "Invalid";
+}
+
+static const char *
+hdmi_audio_sample_size_get_name(enum hdmi_audio_sample_size sample_size)
+{
+	switch (sample_size) {
+	case HDMI_AUDIO_SAMPLE_SIZE_STREAM:
+		return "Refer to Stream Header";
+	case HDMI_AUDIO_SAMPLE_SIZE_16:
+		return "16 bit";
+	case HDMI_AUDIO_SAMPLE_SIZE_20:
+		return "20 bit";
+	case HDMI_AUDIO_SAMPLE_SIZE_24:
+		return "24 bit";
+	}
+	return "Invalid";
+}
+
+static const char *
+hdmi_audio_sample_frequency_get_name(enum hdmi_audio_sample_frequency freq)
+{
+	switch (freq) {
+	case HDMI_AUDIO_SAMPLE_FREQUENCY_STREAM:
+		return "Refer to Stream Header";
+	case HDMI_AUDIO_SAMPLE_FREQUENCY_32000:
+		return "32 kHz";
+	case HDMI_AUDIO_SAMPLE_FREQUENCY_44100:
+		return "44.1 kHz (CD)";
+	case HDMI_AUDIO_SAMPLE_FREQUENCY_48000:
+		return "48 kHz";
+	case HDMI_AUDIO_SAMPLE_FREQUENCY_88200:
+		return "88.2 kHz";
+	case HDMI_AUDIO_SAMPLE_FREQUENCY_96000:
+		return "96 kHz";
+	case HDMI_AUDIO_SAMPLE_FREQUENCY_176400:
+		return "176.4 kHz";
+	case HDMI_AUDIO_SAMPLE_FREQUENCY_192000:
+		return "192 kHz";
+	}
+	return "Invalid";
+}
+
+static const char *
+hdmi_audio_coding_type_ext_get_name(enum hdmi_audio_coding_type_ext ctx)
+{
+	if (ctx < 0 || ctx > 0x1f)
+		return "Invalid";
+
+	switch (ctx) {
+	case HDMI_AUDIO_CODING_TYPE_EXT_CT:
+		return "Refer to CT";
+	case HDMI_AUDIO_CODING_TYPE_EXT_HE_AAC:
+		return "HE AAC";
+	case HDMI_AUDIO_CODING_TYPE_EXT_HE_AAC_V2:
+		return "HE AAC v2";
+	case HDMI_AUDIO_CODING_TYPE_EXT_MPEG_SURROUND:
+		return "MPEG SURROUND";
+	case HDMI_AUDIO_CODING_TYPE_EXT_MPEG4_HE_AAC:
+		return "MPEG-4 HE AAC";
+	case HDMI_AUDIO_CODING_TYPE_EXT_MPEG4_HE_AAC_V2:
+		return "MPEG-4 HE AAC v2";
+	case HDMI_AUDIO_CODING_TYPE_EXT_MPEG4_AAC_LC:
+		return "MPEG-4 AAC LC";
+	case HDMI_AUDIO_CODING_TYPE_EXT_DRA:
+		return "DRA";
+	case HDMI_AUDIO_CODING_TYPE_EXT_MPEG4_HE_AAC_SURROUND:
+		return "MPEG-4 HE AAC + MPEG Surround";
+	case HDMI_AUDIO_CODING_TYPE_EXT_MPEG4_AAC_LC_SURROUND:
+		return "MPEG-4 AAC LC + MPEG Surround";
+	}
+	return "Reserved";
+}
+
+static void hdmi_audio_infoframe_log(const char *level,
+				     struct device *dev,
+				     const struct hdmi_audio_infoframe *frame)
+{
+	hdmi_infoframe_log_header(level, dev,
+				  (const struct hdmi_any_infoframe *)frame);
+
+	if (frame->channels)
+		hdmi_log("    channels: %u\n", frame->channels - 1);
+	else
+		hdmi_log("    channels: Refer to stream header\n");
+	hdmi_log("    coding type: %s\n",
+			hdmi_audio_coding_type_get_name(frame->coding_type));
+	hdmi_log("    sample size: %s\n",
+			hdmi_audio_sample_size_get_name(frame->sample_size));
+	hdmi_log("    sample frequency: %s\n",
+			hdmi_audio_sample_frequency_get_name(frame->sample_frequency));
+	hdmi_log("    coding type ext: %s\n",
+			hdmi_audio_coding_type_ext_get_name(frame->coding_type_ext));
+	hdmi_log("    channel allocation: 0x%x\n",
+			frame->channel_allocation);
+	hdmi_log("    level shift value: %u dB\n",
+			frame->level_shift_value);
+	hdmi_log("    downmix inhibit: %s\n",
+			frame->downmix_inhibit ? "Yes" : "No");
+}
+
+static void hdmi_drm_infoframe_log(const char *level,
+				   struct device *dev,
+				   const struct hdmi_drm_infoframe *frame)
+{
+	int i;
+
+	hdmi_infoframe_log_header(level, dev,
+				  (struct hdmi_any_infoframe *)frame);
+	hdmi_log("length: %d\n", frame->length);
+	hdmi_log("metadata type: %d\n", frame->metadata_type);
+	hdmi_log("eotf: %d\n", frame->eotf);
+	for (i = 0; i < 3; i++) {
+		hdmi_log("x[%d]: %d\n", i, frame->display_primaries[i].x);
+		hdmi_log("y[%d]: %d\n", i, frame->display_primaries[i].y);
+	}
+
+	hdmi_log("white point x: %d\n", frame->white_point.x);
+	hdmi_log("white point y: %d\n", frame->white_point.y);
+
+	hdmi_log("max_display_mastering_luminance: %d\n",
+		 frame->max_display_mastering_luminance);
+	hdmi_log("min_display_mastering_luminance: %d\n",
+		 frame->min_display_mastering_luminance);
+
+	hdmi_log("max_cll: %d\n", frame->max_cll);
+	hdmi_log("max_fall: %d\n", frame->max_fall);
+}
+
+static const char *
+hdmi_3d_structure_get_name(enum hdmi_3d_structure s3d_struct)
+{
+	if (s3d_struct < 0 || s3d_struct > 0xf)
+		return "Invalid";
+
+	switch (s3d_struct) {
+	case HDMI_3D_STRUCTURE_FRAME_PACKING:
+		return "Frame Packing";
+	case HDMI_3D_STRUCTURE_FIELD_ALTERNATIVE:
+		return "Field Alternative";
+	case HDMI_3D_STRUCTURE_LINE_ALTERNATIVE:
+		return "Line Alternative";
+	case HDMI_3D_STRUCTURE_SIDE_BY_SIDE_FULL:
+		return "Side-by-side (Full)";
+	case HDMI_3D_STRUCTURE_L_DEPTH:
+		return "L + Depth";
+	case HDMI_3D_STRUCTURE_L_DEPTH_GFX_GFX_DEPTH:
+		return "L + Depth + Graphics + Graphics-depth";
+	case HDMI_3D_STRUCTURE_TOP_AND_BOTTOM:
+		return "Top-and-Bottom";
+	case HDMI_3D_STRUCTURE_SIDE_BY_SIDE_HALF:
+		return "Side-by-side (Half)";
+	default:
+		break;
+	}
+	return "Reserved";
+}
+
+static void
+hdmi_vendor_any_infoframe_log(const char *level,
+			      struct device *dev,
+			      const union hdmi_vendor_any_infoframe *frame)
+{
+	const struct hdmi_vendor_infoframe *hvf = &frame->hdmi;
+
+	hdmi_infoframe_log_header(level, dev,
+				  (const struct hdmi_any_infoframe *)frame);
+
+	if (frame->any.oui != HDMI_IEEE_OUI) {
+		hdmi_log("    not a HDMI vendor infoframe\n");
+		return;
+	}
+	if (hvf->vic == 0 && hvf->s3d_struct == HDMI_3D_STRUCTURE_INVALID) {
+		hdmi_log("    empty frame\n");
+		return;
+	}
+
+	if (hvf->vic)
+		hdmi_log("    HDMI VIC: %u\n", hvf->vic);
+	if (hvf->s3d_struct != HDMI_3D_STRUCTURE_INVALID) {
+		hdmi_log("    3D structure: %s\n",
+				hdmi_3d_structure_get_name(hvf->s3d_struct));
+		if (hvf->s3d_struct >= HDMI_3D_STRUCTURE_SIDE_BY_SIDE_HALF)
+			hdmi_log("    3D extension data: %d\n",
+					hvf->s3d_ext_data);
+	}
+}
+
+/**
+ * hdmi_infoframe_log() - log info of HDMI infoframe
+ * @level: logging level
+ * @dev: device
+ * @frame: HDMI infoframe
+ */
+void hdmi_infoframe_log(const char *level,
+			struct device *dev,
+			const union hdmi_infoframe *frame)
+{
+	switch (frame->any.type) {
+	case HDMI_INFOFRAME_TYPE_AVI:
+		hdmi_avi_infoframe_log(level, dev, &frame->avi);
+		break;
+	case HDMI_INFOFRAME_TYPE_SPD:
+		hdmi_spd_infoframe_log(level, dev, &frame->spd);
+		break;
+	case HDMI_INFOFRAME_TYPE_AUDIO:
+		hdmi_audio_infoframe_log(level, dev, &frame->audio);
+		break;
+	case HDMI_INFOFRAME_TYPE_VENDOR:
+		hdmi_vendor_any_infoframe_log(level, dev, &frame->vendor);
+		break;
+	case HDMI_INFOFRAME_TYPE_DRM:
+		hdmi_drm_infoframe_log(level, dev, &frame->drm);
+		break;
+	}
+}
+EXPORT_SYMBOL(hdmi_infoframe_log);
+
+/**
+ * hdmi_avi_infoframe_unpack() - unpack binary buffer to a HDMI AVI infoframe
+ * @frame: HDMI AVI infoframe
+ * @buffer: source buffer
+ * @size: size of buffer
+ *
+ * Unpacks the information contained in binary @buffer into a structured
+ * @frame of the HDMI Auxiliary Video (AVI) information frame.
+ * Also verifies the checksum as required by section 5.3.5 of the HDMI 1.4
+ * specification.
+ *
+ * Returns 0 on success or a negative error code on failure.
+ */
+static int hdmi_avi_infoframe_unpack(struct hdmi_avi_infoframe *frame,
+				     const void *buffer, size_t size)
+{
+	const u8 *ptr = buffer;
+
+	if (size < HDMI_INFOFRAME_SIZE(AVI))
+		return -EINVAL;
+
+	if (ptr[0] != HDMI_INFOFRAME_TYPE_AVI ||
+	    ptr[1] != 2 ||
+	    ptr[2] != HDMI_AVI_INFOFRAME_SIZE)
+		return -EINVAL;
+
+	if (hdmi_infoframe_checksum(buffer, HDMI_INFOFRAME_SIZE(AVI)) != 0)
+		return -EINVAL;
+
+	hdmi_avi_infoframe_init(frame);
+
+	ptr += HDMI_INFOFRAME_HEADER_SIZE;
+
+	frame->colorspace = (ptr[0] >> 5) & 0x3;
+	if (ptr[0] & 0x10)
+		frame->active_aspect = ptr[1] & 0xf;
+	if (ptr[0] & 0x8) {
+		frame->top_bar = (ptr[6] << 8) | ptr[5];
+		frame->bottom_bar = (ptr[8] << 8) | ptr[7];
+	}
+	if (ptr[0] & 0x4) {
+		frame->left_bar = (ptr[10] << 8) | ptr[9];
+		frame->right_bar = (ptr[12] << 8) | ptr[11];
+	}
+	frame->scan_mode = ptr[0] & 0x3;
+
+	frame->colorimetry = (ptr[1] >> 6) & 0x3;
+	frame->picture_aspect = (ptr[1] >> 4) & 0x3;
+	frame->active_aspect = ptr[1] & 0xf;
+
+	frame->itc = ptr[2] & 0x80 ? true : false;
+	frame->extended_colorimetry = (ptr[2] >> 4) & 0x7;
+	frame->quantization_range = (ptr[2] >> 2) & 0x3;
+	frame->nups = ptr[2] & 0x3;
+
+	frame->video_code = ptr[3] & 0x7f;
+	frame->ycc_quantization_range = (ptr[4] >> 6) & 0x3;
+	frame->content_type = (ptr[4] >> 4) & 0x3;
+
+	frame->pixel_repeat = ptr[4] & 0xf;
+
+	return 0;
+}
+
+/**
+ * hdmi_spd_infoframe_unpack() - unpack binary buffer to a HDMI SPD infoframe
+ * @frame: HDMI SPD infoframe
+ * @buffer: source buffer
+ * @size: size of buffer
+ *
+ * Unpacks the information contained in binary @buffer into a structured
+ * @frame of the HDMI Source Product Description (SPD) information frame.
+ * Also verifies the checksum as required by section 5.3.5 of the HDMI 1.4
+ * specification.
+ *
+ * Returns 0 on success or a negative error code on failure.
+ */
+static int hdmi_spd_infoframe_unpack(struct hdmi_spd_infoframe *frame,
+				     const void *buffer, size_t size)
+{
+	const u8 *ptr = buffer;
+	int ret;
+
+	if (size < HDMI_INFOFRAME_SIZE(SPD))
+		return -EINVAL;
+
+	if (ptr[0] != HDMI_INFOFRAME_TYPE_SPD ||
+	    ptr[1] != 1 ||
+	    ptr[2] != HDMI_SPD_INFOFRAME_SIZE) {
+		return -EINVAL;
+	}
+
+	if (hdmi_infoframe_checksum(buffer, HDMI_INFOFRAME_SIZE(SPD)) != 0)
+		return -EINVAL;
+
+	ptr += HDMI_INFOFRAME_HEADER_SIZE;
+
+	ret = hdmi_spd_infoframe_init(frame, ptr, ptr + 8);
+	if (ret)
+		return ret;
+
+	frame->sdi = ptr[24];
+
+	return 0;
+}
+
+/**
+ * hdmi_audio_infoframe_unpack() - unpack binary buffer to a HDMI AUDIO infoframe
+ * @frame: HDMI Audio infoframe
+ * @buffer: source buffer
+ * @size: size of buffer
+ *
+ * Unpacks the information contained in binary @buffer into a structured
+ * @frame of the HDMI Audio information frame.
+ * Also verifies the checksum as required by section 5.3.5 of the HDMI 1.4
+ * specification.
+ *
+ * Returns 0 on success or a negative error code on failure.
+ */
+static int hdmi_audio_infoframe_unpack(struct hdmi_audio_infoframe *frame,
+				       const void *buffer, size_t size)
+{
+	const u8 *ptr = buffer;
+	int ret;
+
+	if (size < HDMI_INFOFRAME_SIZE(AUDIO))
+		return -EINVAL;
+
+	if (ptr[0] != HDMI_INFOFRAME_TYPE_AUDIO ||
+	    ptr[1] != 1 ||
+	    ptr[2] != HDMI_AUDIO_INFOFRAME_SIZE) {
+		return -EINVAL;
+	}
+
+	if (hdmi_infoframe_checksum(buffer, HDMI_INFOFRAME_SIZE(AUDIO)) != 0)
+		return -EINVAL;
+
+	ret = hdmi_audio_infoframe_init(frame);
+	if (ret)
+		return ret;
+
+	ptr += HDMI_INFOFRAME_HEADER_SIZE;
+
+	frame->channels = ptr[0] & 0x7;
+	frame->coding_type = (ptr[0] >> 4) & 0xf;
+	frame->sample_size = ptr[1] & 0x3;
+	frame->sample_frequency = (ptr[1] >> 2) & 0x7;
+	frame->coding_type_ext = ptr[2] & 0x1f;
+	frame->channel_allocation = ptr[3];
+	frame->level_shift_value = (ptr[4] >> 3) & 0xf;
+	frame->downmix_inhibit = ptr[4] & 0x80 ? true : false;
+
+	return 0;
+}
+
+/**
+ * hdmi_vendor_any_infoframe_unpack() - unpack binary buffer to a HDMI
+ * 	vendor infoframe
+ * @frame: HDMI Vendor infoframe
+ * @buffer: source buffer
+ * @size: size of buffer
+ *
+ * Unpacks the information contained in binary @buffer into a structured
+ * @frame of the HDMI Vendor information frame.
+ * Also verifies the checksum as required by section 5.3.5 of the HDMI 1.4
+ * specification.
+ *
+ * Returns 0 on success or a negative error code on failure.
+ */
+static int
+hdmi_vendor_any_infoframe_unpack(union hdmi_vendor_any_infoframe *frame,
+				 const void *buffer, size_t size)
+{
+	const u8 *ptr = buffer;
+	size_t length;
+	int ret;
+	u8 hdmi_video_format;
+	struct hdmi_vendor_infoframe *hvf = &frame->hdmi;
+
+	if (size < HDMI_INFOFRAME_HEADER_SIZE)
+		return -EINVAL;
+
+	if (ptr[0] != HDMI_INFOFRAME_TYPE_VENDOR ||
+	    ptr[1] != 1 ||
+	    (ptr[2] != 4 && ptr[2] != 5 && ptr[2] != 6))
+		return -EINVAL;
+
+	length = ptr[2];
+
+	if (size < HDMI_INFOFRAME_HEADER_SIZE + length)
+		return -EINVAL;
+
+	if (hdmi_infoframe_checksum(buffer,
+				    HDMI_INFOFRAME_HEADER_SIZE + length) != 0)
+		return -EINVAL;
+
+	ptr += HDMI_INFOFRAME_HEADER_SIZE;
+
+	/* HDMI OUI */
+	if ((ptr[0] != 0x03) ||
+	    (ptr[1] != 0x0c) ||
+	    (ptr[2] != 0x00))
+		return -EINVAL;
+
+	hdmi_video_format = ptr[3] >> 5;
+
+	if (hdmi_video_format > 0x2)
+		return -EINVAL;
+
+	ret = hdmi_vendor_infoframe_init(hvf);
+	if (ret)
+		return ret;
+
+	hvf->length = length;
+
+	if (hdmi_video_format == 0x2) {
+		if (length != 5 && length != 6)
+			return -EINVAL;
+		hvf->s3d_struct = ptr[4] >> 4;
+		if (hvf->s3d_struct >= HDMI_3D_STRUCTURE_SIDE_BY_SIDE_HALF) {
+			if (length != 6)
+				return -EINVAL;
+			hvf->s3d_ext_data = ptr[5] >> 4;
+		}
+	} else if (hdmi_video_format == 0x1) {
+		if (length != 5)
+			return -EINVAL;
+		hvf->vic = ptr[4];
+	} else {
+		if (length != 4)
+			return -EINVAL;
+	}
+
+	return 0;
+}
+
+/**
+ * hdmi_drm_infoframe_unpack_only() - unpack binary buffer of CTA-861-G DRM
+ *                                    infoframe DataBytes to a HDMI DRM
+ *                                    infoframe
+ * @frame: HDMI DRM infoframe
+ * @buffer: source buffer
+ * @size: size of buffer
+ *
+ * Unpacks CTA-861-G DRM infoframe DataBytes contained in the binary @buffer
+ * into a structured @frame of the HDMI Dynamic Range and Mastering (DRM)
+ * infoframe.
+ *
+ * Returns 0 on success or a negative error code on failure.
+ */
+int hdmi_drm_infoframe_unpack_only(struct hdmi_drm_infoframe *frame,
+				   const void *buffer, size_t size)
+{
+	const u8 *ptr = buffer;
+	const u8 *temp;
+	u8 x_lsb, x_msb;
+	u8 y_lsb, y_msb;
+	int ret;
+	int i;
+
+	if (size < HDMI_DRM_INFOFRAME_SIZE)
+		return -EINVAL;
+
+	ret = hdmi_drm_infoframe_init(frame);
+	if (ret)
+		return ret;
+
+	frame->eotf = ptr[0] & 0x7;
+	frame->metadata_type = ptr[1] & 0x7;
+
+	temp = ptr + 2;
+	for (i = 0; i < 3; i++) {
+		x_lsb = *temp++;
+		x_msb = *temp++;
+		frame->display_primaries[i].x = (x_msb << 8) | x_lsb;
+		y_lsb = *temp++;
+		y_msb = *temp++;
+		frame->display_primaries[i].y = (y_msb << 8) | y_lsb;
+	}
+
+	frame->white_point.x = (ptr[15] << 8) | ptr[14];
+	frame->white_point.y = (ptr[17] << 8) | ptr[16];
+
+	frame->max_display_mastering_luminance = (ptr[19] << 8) | ptr[18];
+	frame->min_display_mastering_luminance = (ptr[21] << 8) | ptr[20];
+	frame->max_cll = (ptr[23] << 8) | ptr[22];
+	frame->max_fall = (ptr[25] << 8) | ptr[24];
+
+	return 0;
+}
+EXPORT_SYMBOL(hdmi_drm_infoframe_unpack_only);
+
+/**
+ * hdmi_drm_infoframe_unpack() - unpack binary buffer to a HDMI DRM infoframe
+ * @frame: HDMI DRM infoframe
+ * @buffer: source buffer
+ * @size: size of buffer
+ *
+ * Unpacks the CTA-861-G DRM infoframe contained in the binary @buffer into
+ * a structured @frame of the HDMI Dynamic Range and Mastering (DRM)
+ * infoframe. It also verifies the checksum as required by section 5.3.5 of
+ * the HDMI 1.4 specification.
+ *
+ * Returns 0 on success or a negative error code on failure.
+ */
+static int hdmi_drm_infoframe_unpack(struct hdmi_drm_infoframe *frame,
+				     const void *buffer, size_t size)
+{
+	const u8 *ptr = buffer;
+	int ret;
+
+	if (size < HDMI_INFOFRAME_SIZE(DRM))
+		return -EINVAL;
+
+	if (ptr[0] != HDMI_INFOFRAME_TYPE_DRM ||
+	    ptr[1] != 1 ||
+	    ptr[2] != HDMI_DRM_INFOFRAME_SIZE)
+		return -EINVAL;
+
+	if (hdmi_infoframe_checksum(buffer, HDMI_INFOFRAME_SIZE(DRM)) != 0)
+		return -EINVAL;
+
+	ret = hdmi_drm_infoframe_unpack_only(frame, ptr + HDMI_INFOFRAME_HEADER_SIZE,
+					     size - HDMI_INFOFRAME_HEADER_SIZE);
+	return ret;
+}
+
+/**
+ * hdmi_infoframe_unpack() - unpack binary buffer to a HDMI infoframe
+ * @frame: HDMI infoframe
+ * @buffer: source buffer
+ * @size: size of buffer
+ *
+ * Unpacks the information contained in binary buffer @buffer into a structured
+ * @frame of a HDMI infoframe.
+ * Also verifies the checksum as required by section 5.3.5 of the HDMI 1.4
+ * specification.
+ *
+ * Returns 0 on success or a negative error code on failure.
+ */
+int hdmi_infoframe_unpack(union hdmi_infoframe *frame,
+			  const void *buffer, size_t size)
+{
+	int ret;
+	const u8 *ptr = buffer;
+
+	if (size < HDMI_INFOFRAME_HEADER_SIZE)
+		return -EINVAL;
+
+	switch (ptr[0]) {
+	case HDMI_INFOFRAME_TYPE_AVI:
+		ret = hdmi_avi_infoframe_unpack(&frame->avi, buffer, size);
+		break;
+	case HDMI_INFOFRAME_TYPE_DRM:
+		ret = hdmi_drm_infoframe_unpack(&frame->drm, buffer, size);
+		break;
+	case HDMI_INFOFRAME_TYPE_SPD:
+		ret = hdmi_spd_infoframe_unpack(&frame->spd, buffer, size);
+		break;
+	case HDMI_INFOFRAME_TYPE_AUDIO:
+		ret = hdmi_audio_infoframe_unpack(&frame->audio, buffer, size);
+		break;
+	case HDMI_INFOFRAME_TYPE_VENDOR:
+		ret = hdmi_vendor_any_infoframe_unpack(&frame->vendor, buffer, size);
+		break;
+	default:
+		ret = -EINVAL;
+		break;
+	}
+
+	return ret;
+}
+EXPORT_SYMBOL(hdmi_infoframe_unpack);

--- a/sys/compat/linuxkpi/common/src/linux_hdmi.c
+++ b/sys/compat/linuxkpi/common/src/linux_hdmi.c
@@ -226,6 +226,9 @@ int hdmi_spd_infoframe_init(struct hdmi_spd_infoframe *frame,
 {
 	size_t len;
 
+	if (frame == NULL || vendor == NULL || product == NULL)
+		return -EINVAL;
+
 	memset(frame, 0, sizeof(*frame));
 
 	frame->type = HDMI_INFOFRAME_TYPE_SPD;

--- a/sys/compat/linuxkpi/common/src/linux_pci.c
+++ b/sys/compat/linuxkpi/common/src/linux_pci.c
@@ -73,6 +73,10 @@
 #include "backlight_if.h"
 #include "pcib_if.h"
 
+const char *pci_power_names[] = {
+	"UNKNOWN", "D0", "D1", "D2", "D3hot", "D3cold"
+};
+
 /* Undef the linux function macro defined in linux/pci.h */
 #undef pci_get_class
 

--- a/sys/compat/linuxkpi/common/src/linux_tasklet.c
+++ b/sys/compat/linuxkpi/common/src/linux_tasklet.c
@@ -83,7 +83,10 @@ tasklet_handler(void *arg)
 				/* reset executing state */
 				TASKLET_ST_SET(ts, TASKLET_ST_EXEC);
 
-				ts->func(ts->data);
+				if (ts->use_callback)
+					ts->callback(ts);
+				else
+					ts->func(ts->data);
 
 			} while (TASKLET_ST_CMPSET(ts, TASKLET_ST_EXEC,
 			        TASKLET_ST_IDLE) == 0);
@@ -147,9 +150,24 @@ tasklet_init(struct tasklet_struct *ts,
 	ts->entry.tqe_prev = NULL;
 	ts->entry.tqe_next = NULL;
 	ts->func = func;
+	ts->callback = NULL;
 	ts->data = data;
 	atomic_set_int(&ts->tasklet_state, TASKLET_ST_IDLE);
 	atomic_set(&ts->count, 0);
+	ts->use_callback = false;
+}
+
+void
+tasklet_setup(struct tasklet_struct *ts, tasklet_callback_t *c)
+{
+	ts->entry.tqe_prev = NULL;
+	ts->entry.tqe_next = NULL;
+	ts->func = NULL;
+	ts->callback = c;
+	ts->data = 0;
+	atomic_set_int(&ts->tasklet_state, TASKLET_ST_IDLE);
+	atomic_set(&ts->count, 0);
+	ts->use_callback = true;
 }
 
 void

--- a/sys/compat/linuxkpi/common/src/linuxkpi_hdmikmod.c
+++ b/sys/compat/linuxkpi/common/src/linuxkpi_hdmikmod.c
@@ -1,0 +1,7 @@
+/* Public domain. */
+
+#include <sys/param.h>
+#include <sys/module.h>
+
+MODULE_VERSION(linuxkpi_hdmi, 1);
+MODULE_DEPEND(linuxkpi_hdmi, linuxkpi, 1, 1, 1);

--- a/sys/compat/linuxkpi/common/src/linuxkpi_videokmod.c
+++ b/sys/compat/linuxkpi/common/src/linuxkpi_videokmod.c
@@ -1,0 +1,7 @@
+/* Public domain. */
+
+#include <sys/param.h>
+#include <sys/module.h>
+
+MODULE_VERSION(linuxkpi_video, 1);
+MODULE_DEPEND(linuxkpi_video, linuxkpi, 1, 1, 1);

--- a/sys/modules/Makefile
+++ b/sys/modules/Makefile
@@ -224,6 +224,8 @@ SUBDIR=	\
 	libmchain \
 	lindebugfs \
 	linuxkpi \
+	linuxkpi_hdmi \
+	linuxkpi_video \
 	linuxkpi_wlan \
 	${_lio} \
 	lpt \

--- a/sys/modules/linuxkpi_hdmi/Makefile
+++ b/sys/modules/linuxkpi_hdmi/Makefile
@@ -1,0 +1,14 @@
+.PATH:	${SRCTOP}/sys/compat/linuxkpi/common/src
+
+KMOD=	linuxkpi_hdmi
+SRCS=	linux_hdmi.c \
+	linuxkpi_hdmikmod.c
+
+SRCS+=	${LINUXKPI_GENSRCS}
+
+CFLAGS+=		${LINUXKPI_INCLUDES}
+CFLAGS.linux_hdmi.c=	-Wno-cast-qual
+
+EXPORT_SYMS=	YES
+
+.include <bsd.kmod.mk>

--- a/sys/modules/linuxkpi_video/Makefile
+++ b/sys/modules/linuxkpi_video/Makefile
@@ -1,0 +1,16 @@
+.PATH:	${SRCTOP}/sys/compat/linuxkpi/common/src
+
+KMOD=	linuxkpi_video
+SRCS=	linux_hdmi.c \
+	linux_aperture.c \
+	linux_cmdline.c \
+	linuxkpi_videokmod.c
+
+SRCS+=	${LINUXKPI_GENSRCS}
+
+CFLAGS+=		${LINUXKPI_INCLUDES}
+CFLAGS.linux_hdmi.c=	-Wno-cast-qual
+
+EXPORT_SYMS=	YES
+
+.include <bsd.kmod.mk>


### PR DESCRIPTION
## What

Bring MidnightBSD's `sys/compat/linuxkpi` up to the level required by
`graphics/drm-515-kmod` (the Linux 5.15 DRM stack: drm/ttm/dmabuf/amdgpu/
i915kms/radeonkms). With this branch, the drm-515-kmod port **builds and
links all six modules** on amd64. See `drm.md` at the repo root for the full
gap analysis and rationale.

**Scope: build + link only. Modules are not loaded** — runtime/KMS bring-up
(vt/newcons console handoff, IRQs, suspend/resume, modesetting) is follow-on.

## Approach: hybrid, not wholesale

MidnightBSD's LinuxKPI sits around FreeBSD 13.5-STABLE level. A wholesale
FreeBSD 14 LinuxKPI import was evaluated and **rejected**: it drags base-kernel
reworks MidnightBSD lacks (AST framework, protosw refactor, file/fileops API),
which would be a much larger and riskier base uplift than the DRM port itself.

Instead this keeps MidnightBSD's base-compatible LinuxKPI files and imports
only the FreeBSD 14 *additive* pieces, plus per-symbol backports — each one
driven by a real drm-515 build failure and taken verbatim from FreeBSD 14:

- additive FreeBSD 14 headers (aperture, iosys-map, hdmi, iommu, irqdomain,
  util_macros, time64, limits, build_bug, …) and the `linuxkpi_hdmi` /
  `linuxkpi_video` modules
- single-argument `vm_operations_struct.fault`
- tasklet callback API (`tasklet_setup`, `from_tasklet`, `->callback`)
- PCI/device power bits (`dev_pm_info`, `pci_dev.current_state`,
  `pci_power_name()`), `pcie_aspm_enabled()`
- `devm_add_action()`, `bitmap_to_arr32()`, `acpi_put_table()`,
  `noinline_for_stack`, INTEL_FAM6 Alder Lake ids, `ZERO_SIZE_PTR`
- move BUILD_BUG → `build_bug.h` and U*_MAX → `limits.h` (both included from
  `kernel.h`); make `kernel.h` pull in `math64.h`

## Verification

- `cd /usr/mports/graphics/drm-515-kmod && make build SRC_BASE=/usr/src`
  builds all six `.ko` clean (confirmed by a clean rebuild from fresh extract).
- Regression-checked the shared-header changes: the only risky one
  (`mm.h` `.fault` 1-arg) is safe — no other in-tree `vm_operations_struct`
  user implements `.fault` (mlx4_ib/mlx5_ib/irdma use only open/close).
  `linuxkpi_wlan` / `linuxkpi_hdmi` / `linuxkpi_video` all rebuild clean.

## Companion

Needs the new port in MidnightBSD/mports (`graphics/drm-515-kmod`, separate PR);
that port depends on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)