### PR TITLE
ck: fix buildkernel limits.h failure on Linux cross-compile

### DIFF
--- a/sys/contrib/ck/include/ck_limits.h
+++ b/sys/contrib/ck/include/ck_limits.h
@@ -40,7 +40,7 @@
 #define UINT64_MAX ULLONG_MAX
 #endif
 
-#elif defined(__MidnightBSD__) && defined(_KERNEL)
+#elif defined(_KERNEL)	/* any BSD kernel build; compiler may not predefine __MidnightBSD__/__FreeBSD__ */
 #include <sys/stdint.h>
 #include <sys/limits.h>
 #else


### PR DESCRIPTION
## Problem

`buildkernel` in CI (Linux-hosted cross-compile) fails at genassym:

```
contrib/ck/include/ck_limits.h:47:10: fatal error: 'limits.h' file not found
   47 | #include <limits.h>
```

## Cause

`ck_limits.h`'s kernel branch was gated on `defined(__MidnightBSD__) && defined(_KERNEL)`. A Linux-hosted cross clang targeting MidnightBSD predefines `__FreeBSD__` (the target), **not** `__MidnightBSD__`, and **not** `__linux__`. So the preprocessor skips the `__linux__` branch *and* the `__MidnightBSD__` branch and falls through to `#include <limits.h>`, which can't be found under the kernel's `-nostdinc`.

(Native builds work only because MidnightBSD's own clang predefines `__MidnightBSD__`.)

## Fix

Key the BSD branch on `_KERNEL`. All kernel objects — including `genassym.o` — are compiled with `-D_KERNEL` (`sys/conf/kern.pre.mk:77`), and by this point in the conditional a non-`__linux__` `_KERNEL` build is a BSD kernel, which provides `<sys/limits.h>`. Independent of which platform macro the (cross-)compiler predefines.

## Verification

Simulated the CI cross-compile locally — `-nostdinc -nobuiltininc -D_KERNEL` with `__MidnightBSD__`/`__FreeBSD__`/`__linux__` all undefined — `ck_limits.h` now resolves `<sys/limits.h>` and compiles clean; the native build (with `__MidnightBSD__` defined) is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Fix buildkernel genassym failures on Linux-hosted MidnightBSD cross-compiles by correctly routing _KERNEL builds to BSD kernel limits headers.