### PR TITLE
usr.bin/sqlite3: link the shell against libm (fixes stable/4.0 build)

### DIFF
--- a/usr.bin/sqlite3/Makefile
+++ b/usr.bin/sqlite3/Makefile
@@ -12,6 +12,7 @@ PROG=		sqlite3
 SRCS=		shell.c
 		
 LIBADD+=	sqlite3
+LIBADD+=	m
 # readline
 
 .include <bsd.prog.mk>


### PR DESCRIPTION
## Problem

`stable/4.0` buildworld fails linking the sqlite3 shell:

```
ld: error: undefined symbol: ceil
>>> referenced by shell.c:8194 (contrib/sqlite3/shell.c:8194)
>>>               shell.pieo:(seriesFilter)
ld: error: undefined symbol: floor
cc: error: linker command failed with exit code 1
*** [sqlite3.full] Error code 1
```

## Cause

`contrib/sqlite3/shell.c`'s `generate_series` extension defines
`seriesCeil()`/`seriesFloor()` using `ceil()`/`floor()`. Under the PIE shell
link those resolve to **libm** symbols, but `usr.bin/sqlite3/Makefile` linked
only `libsqlite3` (`LIBADD+= sqlite3`).

## Fix

`LIBADD+= m`.

## Verification

`cd usr.bin/sqlite3 && make` now builds clean — the link picks up `-lm`
(`.../lib/msun -lm`) and `sqlite3.full` links/strips successfully.

Note: `master`'s `usr.bin/sqlite3/Makefile` is identical (no libm) and likely
needs the same change; happy to send a companion PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Build:
- Add libm to the sqlite3 shell link libraries so the build picks up -lm when producing the sqlite3.full binary.