### PR TITLE
usr.bin/sqlite3: link the shell against libm

### DIFF
--- a/usr.bin/sqlite3/Makefile
+++ b/usr.bin/sqlite3/Makefile
@@ -12,6 +12,7 @@ PROG=		sqlite3
 SRCS=		shell.c
 		
 LIBADD+=	sqlite3
+LIBADD+=	m
 # readline
 
 .include <bsd.prog.mk>


### PR DESCRIPTION
Companion to the stable/4.0 fix (#381). `master`'s `usr.bin/sqlite3/Makefile`
is identical and has the same latent link failure.

## Problem

The sqlite3 shell's `generate_series` extension (`seriesCeil`/`seriesFloor`
in `contrib/sqlite3/shell.c`) references `ceil()`/`floor()`, which resolve to
**libm** under the PIE shell link. The Makefile linked only `libsqlite3`:

```
ld: error: undefined symbol: ceil
ld: error: undefined symbol: floor   >>> shell.pieo:(seriesFilter)
*** [sqlite3.full] Error code 1
```

## Fix

`LIBADD+= m`. Verified: `cd usr.bin/sqlite3 && make` links cleanly with `-lm`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Link the sqlite3 shell binary against libm to resolve unresolved math symbol references in the generate_series extension.

Bug Fixes:
- Fix sqlite3 shell link failures caused by unresolved ceil() and floor() symbols when building with PIE.

Build:
- Add libm to the sqlite3 shell link libraries in usr.bin/sqlite3/Makefile.