### PR TITLE
usr.bin/sqlite3: link the shell against libm

### DIFF
--- a/usr.bin/sqlite3/Makefile
+++ b/usr.bin/sqlite3/Makefile
@@ -12,6 +12,7 @@ PROG=		sqlite3
 SRCS=		shell.c
 		
 LIBADD+=	sqlite3
+LIBADD+=	m
 # readline
 
 .include <bsd.prog.mk>


### PR DESCRIPTION
Companion to #381 (stable/4.0) and #382 (master). `stable/4.1`'s
`usr.bin/sqlite3/Makefile` is identical and has the same link failure.

## Problem

The sqlite3 shell's `generate_series` extension (`seriesCeil`/`seriesFloor`
in `contrib/sqlite3/shell.c`) references `ceil()`/`floor()`, which resolve to
**libm** under the PIE shell link; the Makefile linked only `libsqlite3`:

```
ld: error: undefined symbol: ceil
ld: error: undefined symbol: floor   >>> shell.pieo:(seriesFilter)
*** [sqlite3.full] Error code 1
```

## Fix

`LIBADD+= m`. Verified locally: `cd usr.bin/sqlite3 && make` links cleanly with `-lm`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Fix linker errors for the sqlite3 shell by adding libm to the list of linked libraries.