### PR TITLE
sched: add SCHED_MIC, a hybrid-core-aware scheduler derived from ULE

### DIFF
--- a/scheduler.md
+++ b/scheduler.md
@@ -1,0 +1,182 @@
+# SCHED_MIC — a hybrid-core-aware scheduler
+
+`SCHED_MIC` is a new scheduler derived from ULE (`sys/kern/sched_ule.c`). It is
+identical to ULE except that, on x86 CPUs with heterogeneous ("hybrid") cores,
+it weighs four core priority classes when choosing where to run a thread. On
+homogeneous hardware — and on non-x86 architectures — it behaves like ULE, and
+is byte-for-byte identical to ULE placement with `kern.sched.smt_busy_penalty=0`
+(the default 192 primarily changes choices within an SMT-threaded group, though
+it can tip cross-group placement in edge cases since it feeds the group total).
+
+ULE is unchanged and remains the default scheduler. `SCHED_MIC` is opt-in.
+
+## Why
+
+Modern CPUs are no longer uniform:
+
+- **Intel 12th–14th gen and Core Ultra** mix fast P-cores, efficient E-cores,
+  and (on Core Ultra) very-low-power LP-E cores on the SoC tile.
+- **AMD 7950X3D / 7900X3D / 9950X3D / 9900X3D** pair a 3D V-Cache CCD (huge L3,
+  great for latency-sensitive/gaming work) with a higher-clocked compute CCD.
+- **AMD hybrid mobile** parts add dense Zen4c/5c "C" efficiency cores.
+
+ULE treats all of these as interchangeable (apart from SMT), so latency-
+sensitive work can land on a slow core while a fast one sits idle. `SCHED_MIC`
+adds awareness of these classes.
+
+## Core priority classes
+
+Each logical CPU is assigned a static class. The "priority 3" tier is a dynamic
+state (a busy core's free SMT thread), so it is computed at placement time and
+never stored.
+
+| Priority | Meaning | Class constant |
+|---|---|---|
+| 1 | P-core / AMD cache (V-Cache) CCD core — physical | `CPU_CLASS_PERF` (1) |
+| 2 | E-core / AMD compute CCD core / AMD C-core — physical | `CPU_CLASS_EFF` (2) |
+| 3 | Free SMT thread of a *busy* core ("hyperthreaded") | dynamic, not stored |
+| 4 | Intel LP-E core — scheduled last | `CPU_CLASS_LP` (4) |
+
+The global fill rule is **class-1 physical → class-2 physical → SMT siblings →
+LP**. The preference is *soft and tunable*: higher classes fill first, but work
+spills to lower classes once the higher ones carry real load. Nothing is ever
+hard-fenced off, so the machine is never artificially underused.
+
+## How placement works
+
+ULE's `cpu_search_lowest()` walks the `cpu_group` topology tree, summing each
+subtree's load into a `total` and descending the least-loaded path, then picks
+the least-loaded CPU on that path. `SCHED_MIC` folds a per-candidate **class
+cost** into each CPU's load *before* it is summed into `total`
+(`sched_class_cost()` in `sys/kern/sched_mic.c`), so the bias steers both the
+subtree choice and the final CPU pick:
+
+```
+load = l * 256 + sched_class_cost(cg, c, l);
+```
+
+The cost is, on the 256-points-per-thread scale ULE already uses:
+
+- class 2 (efficiency): `+ kern.sched.class_weight_eff`  (default 64)
+- class 4 (LP-E):       `+ kern.sched.class_weight_lp`   (default 512)
+- free thread whose SMT sibling is busy: `+ kern.sched.smt_busy_penalty` (192)
+
+This yields the per-candidate ordering required by the priority list:
+
+```
+idle perf (0) < idle eff (64) < busy-sibling perf (192) < idle LP (512)
+```
+
+The class cost is applied only on the placement path: `sched_lowest()` takes a
+`class_aware` argument that is set by `sched_pickcpu()` but cleared by the
+periodic load balancer (`sched_balance_group()`), and `cpu_search_highest()`
+(the work-steal *source* search) is unmodified. So the balancer and work
+stealing stay class-blind and move work purely by real load; only thread
+*placement* steers by core class. This keeps cache-CCD packing (driven by
+placement) without risking class-driven migration ping-pong.
+
+Because the cost is summed into group totals, a lower-class cluster of N cores
+carries an `N × weight` baseline — which is what keeps LP genuinely near-last
+and packs the AMD cache CCD under load. All crossovers are controlled by the
+sysctls below.
+
+### Worked examples
+
+- **Intel 13900K, all idle**: P-cores (cost 0) fill first, then E-cores (64),
+  LP-E (512) last.
+- **Intel, all P physical busy (1 thread each)**: a half-busy P SMT group costs
+  `256 + 192`; an idle 4-core E module costs `4 × 64 = 256`, so the next thread
+  takes an **E core before a P SMT sibling** (priority 2 before 3).
+- **AMD 7950X3D, all idle**: the cache CCD (class 1) fills first; the 9th thread
+  spills to a compute-CCD **physical** core before any cache-CCD SMT sibling.
+  `kern.sched.prefer_compute=1` swaps the classes so the compute/frequency CCD
+  is preferred instead.
+- **Homogeneous box**: detection leaves every CPU class 1, so all cost terms are
+  zero except the SMT-sibling penalty; set `kern.sched.smt_busy_penalty=0` for
+  byte-identical ULE placement.
+
+## How cores are detected
+
+Detection is x86 machine-dependent, in `sys/x86/x86/mp_x86.c`, guarded by
+`#ifdef SCHED_MIC` (so ULE/4BSD kernels gain no code). A `SYSINIT` at
+`SI_SUB_SMP` uses `smp_rendezvous()` to have **each CPU probe its own CPUID**
+(core type and the size of the L3 it shares), then derives `cpu_core_class[]`.
+Until that runs, the array defaults to all class 1, i.e. plain ULE behavior.
+
+| Case | Method | Reliability |
+|---|---|---|
+| Intel P vs E | CPUID `0x1A` EAX[31:24] (`0x40`=P, `0x20`=E) | architectural |
+| Intel LP-E | small core with **no L3** (SoC-tile LP-E lack L3, unlike compute-tile E-cores); gated by `kern.sched.detect_lpe` | heuristic |
+| AMD X3D CCD | per-CCD L3 size via CPUID `0x8000001D`; the larger-L3 die is the cache die (class 1), the other compute (class 2) | heuristic (method sound) |
+| AMD Zen4c/5c | same larger-L3-is-preferred rule (full CCX has larger L3 than a C CCX) | heuristic |
+
+Graceful fallbacks: non-hybrid Intel, single-CCD AMD, and AMD parts with
+symmetric L3 (e.g. a plain 7950X) leave every CPU class 1 → identical to ULE.
+
+The CPUID cache-size field macros live in `sys/x86/include/specialreg.h`
+(`CPUID_CACHE_*`).
+
+## Tunables (`kern.sched.*`)
+
+| sysctl | default | meaning |
+|---|---|---|
+| `class_weight_eff` | 64 | load penalty for class-2 cores |
+| `class_weight_lp` | 512 | load penalty for class-4 (LP-E) cores |
+| `smt_busy_penalty` | 192 | penalty for a free thread whose SMT sibling is busy; `0` restores ULE SMT behavior |
+| `prefer_compute` | 0 | AMD hybrid CCD: `0` favors the cache (V-Cache) die, `1` favors the compute die |
+| `detect_lpe` | 1 | (boot tunable) detect LP-E cores as class 4; `0` leaves them class 2 |
+| `core_class` | (read-only) | debug dump of per-CPU class, `cpuid:class` pairs |
+
+## Files
+
+| File | Change |
+|---|---|
+| `sys/kern/sched_mic.c` | new; copy of `sched_ule.c` with the cost function, helpers, `cpu_core_class[]`, and new sysctls |
+| `sys/sys/smp.h` | `CPU_CLASS_*` constants and `cpu_core_class[]` extern |
+| `sys/x86/include/specialreg.h` | `CPUID_CACHE_*` macros; `CPUID_HYBRID_NATIVE_MODEL_MASK` |
+| `sys/x86/x86/mp_x86.c` | `SCHED_MIC`-guarded detection (`mic_probe_cpu`, `mic_classify` SYSINIT) |
+| `sys/conf/options`, `sys/conf/files`, `sys/conf/NOTES` | `SCHED_MIC` option/build wiring and documentation |
+| `sys/amd64/conf/MIC` | sample kernel config selecting `SCHED_MIC` |
+
+## Building and trying it
+
+```
+cd /usr/src
+make buildkernel KERNCONF=MIC
+make installkernel KERNCONF=MIC
+```
+
+After booting:
+
+```
+sysctl kern.sched.name          # -> MIC
+sysctl kern.sched.core_class    # per-CPU class dump
+sysctl kern.sched.topology_spec # cross-reference CPU -> cache/CCD
+```
+
+Expected `core_class` counts: 13900K = 8×1 + 16×2; 7950X3D = 8×1 + 8×2; Core
+Ultra includes a cluster of class 4. On homogeneous hardware every CPU is 1.
+
+The Intel detection path has been validated on real Alder Lake silicon (Core
+i7-1260P) by reading the same CPUID leaves per-core from userspace: 8 P-core
+threads → class 1, 8 E-cores → class 2, 0 LP-E. The E-cores report an 18 MB L3,
+so the "small core with no L3 ⇒ LP-E" heuristic correctly leaves them class 2.
+The LP-E, AMD X3D, and AMD C-core paths, and actual placement behavior, still
+need their respective hardware / a booted MIC kernel.
+
+## Limitations / future work
+
+- LP-E detection is heuristic (no architectural bit); `detect_lpe=0` disables it.
+- AMD CPPC "highest performance" is not yet used as a corroborating signal for
+  C-core detection; the L3-size heuristic covers the current parts.
+- Work-stealing (`cpu_search_highest`) is class-blind; it does not yet avoid
+  pulling work onto LP/efficiency cores.
+- The long-term load balancer (`sched_balance_group`) is class-blind by default
+  (the `class_aware` argument to `sched_lowest()` at the balancer call site is
+  `0`). It evens load by real `tdq_load`, so under *sustained* saturation it will
+  migrate work off the preferred cores (cache CCD / P-cores) to equalize,
+  partially eroding the packing that placement establishes. Placement preference
+  therefore holds firmly at light/moderate load and softens at saturation. To
+  test the opposite tradeoff on real hardware — balancer *reinforces* packing —
+  flip that single argument to `1`; which is better is hardware-dependent.
+- `prefer_compute` is global (fine for single-socket consumer X3D parts).

--- a/sys/amd64/conf/MIC
+++ b/sys/amd64/conf/MIC
@@ -1,0 +1,7 @@
+
+include GENERIC
+
+ident	MIC
+
+nooptions	SCHED_ULE
+options 	SCHED_MIC		# Hybrid-core-aware scheduler (ULE-derived)

--- a/sys/conf/NOTES
+++ b/sys/conf/NOTES
@@ -194,7 +194,8 @@ options 	ROOTDEVNAME=\"ufs:da0s2e\"
 #####################################################################
 # Scheduler options:
 #
-# Specifying one of SCHED_4BSD or SCHED_ULE is mandatory.  These options
+# Specifying one of SCHED_4BSD, SCHED_ULE, or SCHED_MIC is mandatory.  These
+# options
 # select which scheduler is compiled in.
 #
 # SCHED_4BSD is the historical, proven, BSD scheduler.  It has a global run
@@ -207,12 +208,21 @@ options 	ROOTDEVNAME=\"ufs:da0s2e\"
 # which leads to better responsiveness even on uniprocessor machines.  This
 # is the default scheduler.
 #
+# SCHED_MIC is SCHED_ULE extended with hybrid-core awareness.  On x86 CPUs with
+# heterogeneous cores it weighs four core priority classes when placing threads:
+# performance cores (Intel P-cores, AMD 3D V-Cache CCD) first, then efficiency
+# cores (Intel E-cores, AMD compute CCD, AMD mobile C-cores), then the second
+# SMT thread of a busy core, then Intel LP-E cores last.  Preference is a soft,
+# tunable bias (see kern.sched.class_weight_*, smt_busy_penalty, prefer_compute).
+# On homogeneous hardware it behaves like SCHED_ULE.
+#
 # SCHED_STATS is a debugging option which keeps some stats in the sysctl
 # tree at 'kern.sched.stats' and is useful for debugging scheduling decisions.
 #
 options 	SCHED_4BSD
 options 	SCHED_STATS
 #options 	SCHED_ULE
+#options 	SCHED_MIC
 
 #####################################################################
 # SMP OPTIONS:

--- a/sys/conf/files
+++ b/sys/conf/files
@@ -3934,6 +3934,7 @@ kern/p1003_1b.c			standard
 kern/posix4_mib.c		standard
 kern/sched_4bsd.c		optional sched_4bsd
 kern/sched_ule.c		optional sched_ule
+kern/sched_mic.c		optional sched_mic
 kern/serdev_if.m		standard
 kern/stack_protector.c		standard \
 	compile-with "${NORMAL_C:N-fstack-protector*}"

--- a/sys/conf/options
+++ b/sys/conf/options
@@ -193,6 +193,7 @@ QUOTA
 SCHED_4BSD	opt_sched.h
 SCHED_STATS	opt_sched.h
 SCHED_ULE	opt_sched.h
+SCHED_MIC	opt_sched.h
 SLEEPQUEUE_PROFILING
 SLHCI_DEBUG	opt_slhci.h
 STACK		opt_stack.h

--- a/sys/kern/sched_mic.c
+++ b/sys/kern/sched_mic.c
@@ -1,0 +1,3391 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2002-2007, Jeffrey Roberson <jeff@freebsd.org>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice unmodified, this list of conditions, and the following
+ *    disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * This file implements the ULE scheduler.  ULE supports independent CPU
+ * run queues and fine grain locking.  It has superior interactive
+ * performance under load even on uni-processor systems.
+ *
+ * etymology:
+ *   ULE is the last three letters in schedule.  It owes its name to a
+ * generic user created for a scheduling system by Paul Mikesell at
+ * Isilon Systems and a general lack of creativity on the part of the author.
+ */
+
+#include <sys/cdefs.h>
+#include "opt_hwpmc_hooks.h"
+#include "opt_sched.h"
+
+#include <sys/param.h>
+#include <sys/systm.h>
+#include <sys/kdb.h>
+#include <sys/kernel.h>
+#include <sys/ktr.h>
+#include <sys/limits.h>
+#include <sys/lock.h>
+#include <sys/mutex.h>
+#include <sys/proc.h>
+#include <sys/resource.h>
+#include <sys/resourcevar.h>
+#include <sys/sched.h>
+#include <sys/sdt.h>
+#include <sys/smp.h>
+#include <sys/sx.h>
+#include <sys/sysctl.h>
+#include <sys/sysproto.h>
+#include <sys/turnstile.h>
+#include <sys/umtxvar.h>
+#include <sys/vmmeter.h>
+#include <sys/cpuset.h>
+#include <sys/sbuf.h>
+
+#ifdef HWPMC_HOOKS
+#include <sys/pmckern.h>
+#endif
+
+#ifdef KDTRACE_HOOKS
+#include <sys/dtrace_bsd.h>
+int __read_mostly		dtrace_vtime_active;
+dtrace_vtime_switch_func_t	dtrace_vtime_switch_func;
+#endif
+
+#include <machine/cpu.h>
+#include <machine/smp.h>
+
+#define	KTR_ULE	0
+
+#define	TS_NAME_LEN (MAXCOMLEN + sizeof(" td ") + sizeof(__XSTRING(UINT_MAX)))
+#define	TDQ_NAME_LEN	(sizeof("sched lock ") + sizeof(__XSTRING(MAXCPU)))
+#define	TDQ_LOADNAME_LEN	(sizeof("CPU ") + sizeof(__XSTRING(MAXCPU)) - 1 + sizeof(" load"))
+
+/*
+ * Thread scheduler specific section.  All fields are protected
+ * by the thread lock.
+ */
+struct td_sched {	
+	struct runq	*ts_runq;	/* Run-queue we're queued on. */
+	short		ts_flags;	/* TSF_* flags. */
+	int		ts_cpu;		/* CPU that we have affinity for. */
+	int		ts_rltick;	/* Real last tick, for affinity. */
+	int		ts_slice;	/* Ticks of slice remaining. */
+	u_int		ts_slptime;	/* Number of ticks we vol. slept */
+	u_int		ts_runtime;	/* Number of ticks we were running */
+	int		ts_ltick;	/* Last tick that we were running on */
+	int		ts_ftick;	/* First tick that we were running on */
+	int		ts_ticks;	/* Tick count */
+#ifdef KTR
+	char		ts_name[TS_NAME_LEN];
+#endif
+};
+/* flags kept in ts_flags */
+#define	TSF_BOUND	0x0001		/* Thread can not migrate. */
+#define	TSF_XFERABLE	0x0002		/* Thread was added as transferable. */
+
+#define	THREAD_CAN_MIGRATE(td)	((td)->td_pinned == 0)
+#define	THREAD_CAN_SCHED(td, cpu)	\
+    CPU_ISSET((cpu), &(td)->td_cpuset->cs_mask)
+
+_Static_assert(sizeof(struct thread) + sizeof(struct td_sched) <=
+    sizeof(struct thread0_storage),
+    "increase struct thread0_storage.t0st_sched size");
+
+/*
+ * Priority ranges used for interactive and non-interactive timeshare
+ * threads.  The timeshare priorities are split up into four ranges.
+ * The first range handles interactive threads.  The last three ranges
+ * (NHALF, x, and NHALF) handle non-interactive threads with the outer
+ * ranges supporting nice values.
+ */
+#define	PRI_TIMESHARE_RANGE	(PRI_MAX_TIMESHARE - PRI_MIN_TIMESHARE + 1)
+#define	PRI_INTERACT_RANGE	((PRI_TIMESHARE_RANGE - SCHED_PRI_NRESV) / 2)
+#define	PRI_BATCH_RANGE		(PRI_TIMESHARE_RANGE - PRI_INTERACT_RANGE)
+
+#define	PRI_MIN_INTERACT	PRI_MIN_TIMESHARE
+#define	PRI_MAX_INTERACT	(PRI_MIN_TIMESHARE + PRI_INTERACT_RANGE - 1)
+#define	PRI_MIN_BATCH		(PRI_MIN_TIMESHARE + PRI_INTERACT_RANGE)
+#define	PRI_MAX_BATCH		PRI_MAX_TIMESHARE
+
+/*
+ * Cpu percentage computation macros and defines.
+ *
+ * SCHED_TICK_SECS:	Number of seconds to average the cpu usage across.
+ * SCHED_TICK_TARG:	Number of hz ticks to average the cpu usage across.
+ * SCHED_TICK_MAX:	Maximum number of ticks before scaling back.
+ * SCHED_TICK_SHIFT:	Shift factor to avoid rounding away results.
+ * SCHED_TICK_HZ:	Compute the number of hz ticks for a given ticks count.
+ * SCHED_TICK_TOTAL:	Gives the amount of time we've been recording ticks.
+ */
+#define	SCHED_TICK_SECS		10
+#define	SCHED_TICK_TARG		(hz * SCHED_TICK_SECS)
+#define	SCHED_TICK_MAX		(SCHED_TICK_TARG + hz)
+#define	SCHED_TICK_SHIFT	10
+#define	SCHED_TICK_HZ(ts)	((ts)->ts_ticks >> SCHED_TICK_SHIFT)
+#define	SCHED_TICK_TOTAL(ts)	(max((ts)->ts_ltick - (ts)->ts_ftick, hz))
+
+/*
+ * These macros determine priorities for non-interactive threads.  They are
+ * assigned a priority based on their recent cpu utilization as expressed
+ * by the ratio of ticks to the tick total.  NHALF priorities at the start
+ * and end of the MIN to MAX timeshare range are only reachable with negative
+ * or positive nice respectively.
+ *
+ * PRI_RANGE:	Priority range for utilization dependent priorities.
+ * PRI_NRESV:	Number of nice values.
+ * PRI_TICKS:	Compute a priority in PRI_RANGE from the ticks count and total.
+ * PRI_NICE:	Determines the part of the priority inherited from nice.
+ */
+#define	SCHED_PRI_NRESV		(PRIO_MAX - PRIO_MIN)
+#define	SCHED_PRI_NHALF		(SCHED_PRI_NRESV / 2)
+#define	SCHED_PRI_MIN		(PRI_MIN_BATCH + SCHED_PRI_NHALF)
+#define	SCHED_PRI_MAX		(PRI_MAX_BATCH - SCHED_PRI_NHALF)
+#define	SCHED_PRI_RANGE		(SCHED_PRI_MAX - SCHED_PRI_MIN + 1)
+#define	SCHED_PRI_TICKS(ts)						\
+    (SCHED_TICK_HZ((ts)) /						\
+    (roundup(SCHED_TICK_TOTAL((ts)), SCHED_PRI_RANGE) / SCHED_PRI_RANGE))
+#define	SCHED_PRI_NICE(nice)	(nice)
+
+/*
+ * These determine the interactivity of a process.  Interactivity differs from
+ * cpu utilization in that it expresses the voluntary time slept vs time ran
+ * while cpu utilization includes all time not running.  This more accurately
+ * models the intent of the thread.
+ *
+ * SLP_RUN_MAX:	Maximum amount of sleep time + run time we'll accumulate
+ *		before throttling back.
+ * SLP_RUN_FORK:	Maximum slp+run time to inherit at fork time.
+ * INTERACT_MAX:	Maximum interactivity value.  Smaller is better.
+ * INTERACT_THRESH:	Threshold for placement on the current runq.
+ */
+#define	SCHED_SLP_RUN_MAX	((hz * 5) << SCHED_TICK_SHIFT)
+#define	SCHED_SLP_RUN_FORK	((hz / 2) << SCHED_TICK_SHIFT)
+#define	SCHED_INTERACT_MAX	(100)
+#define	SCHED_INTERACT_HALF	(SCHED_INTERACT_MAX / 2)
+#define	SCHED_INTERACT_THRESH	(30)
+
+/*
+ * These parameters determine the slice behavior for batch work.
+ */
+#define	SCHED_SLICE_DEFAULT_DIVISOR	10	/* ~94 ms, 12 stathz ticks. */
+#define	SCHED_SLICE_MIN_DIVISOR		6	/* DEFAULT/MIN = ~16 ms. */
+
+/* Flags kept in td_flags. */
+#define	TDF_PICKCPU	TDF_SCHED0	/* Thread should pick new CPU. */
+#define	TDF_SLICEEND	TDF_SCHED2	/* Thread time slice is over. */
+
+/*
+ * tickincr:		Converts a stathz tick into a hz domain scaled by
+ *			the shift factor.  Without the shift the error rate
+ *			due to rounding would be unacceptably high.
+ * realstathz:		stathz is sometimes 0 and run off of hz.
+ * sched_slice:		Runtime of each thread before rescheduling.
+ * preempt_thresh:	Priority threshold for preemption and remote IPIs.
+ */
+static u_int __read_mostly sched_interact = SCHED_INTERACT_THRESH;
+static int __read_mostly tickincr = 8 << SCHED_TICK_SHIFT;
+static int __read_mostly realstathz = 127;	/* reset during boot. */
+static int __read_mostly sched_slice = 10;	/* reset during boot. */
+static int __read_mostly sched_slice_min = 1;	/* reset during boot. */
+#ifdef PREEMPTION
+#ifdef FULL_PREEMPTION
+static int __read_mostly preempt_thresh = PRI_MAX_IDLE;
+#else
+static int __read_mostly preempt_thresh = PRI_MIN_KERN;
+#endif
+#else 
+static int __read_mostly preempt_thresh = 0;
+#endif
+static int __read_mostly static_boost = PRI_MIN_BATCH;
+static int __read_mostly sched_idlespins = 10000;
+static int __read_mostly sched_idlespinthresh = -1;
+
+/*
+ * tdq - per processor runqs and statistics.  A mutex synchronizes access to
+ * most fields.  Some fields are loaded or modified without the mutex.
+ *
+ * Locking protocols:
+ * (c)  constant after initialization
+ * (f)  flag, set with the tdq lock held, cleared on local CPU
+ * (l)  all accesses are CPU-local
+ * (ls) stores are performed by the local CPU, loads may be lockless
+ * (t)  all accesses are protected by the tdq mutex
+ * (ts) stores are serialized by the tdq mutex, loads may be lockless
+ */
+struct tdq {
+	/* 
+	 * Ordered to improve efficiency of cpu_search() and switch().
+	 * tdq_lock is padded to avoid false sharing with tdq_load and
+	 * tdq_cpu_idle.
+	 */
+	struct mtx_padalign tdq_lock;	/* run queue lock. */
+	struct cpu_group *tdq_cg;	/* (c) Pointer to cpu topology. */
+	struct thread	*tdq_curthread;	/* (t) Current executing thread. */
+	int		tdq_load;	/* (ts) Aggregate load. */
+	int		tdq_sysload;	/* (ts) For loadavg, !ITHD load. */
+	int		tdq_cpu_idle;	/* (ls) cpu_idle() is active. */
+	int		tdq_transferable; /* (ts) Transferable thread count. */
+	short		tdq_switchcnt;	/* (l) Switches this tick. */
+	short		tdq_oldswitchcnt; /* (l) Switches last tick. */
+	u_char		tdq_lowpri;	/* (ts) Lowest priority thread. */
+	u_char		tdq_owepreempt;	/* (f) Remote preemption pending. */
+	u_char		tdq_idx;	/* (t) Current insert index. */
+	u_char		tdq_ridx;	/* (t) Current removal index. */
+	int		tdq_id;		/* (c) cpuid. */
+	struct runq	tdq_realtime;	/* (t) real-time run queue. */
+	struct runq	tdq_timeshare;	/* (t) timeshare run queue. */
+	struct runq	tdq_idle;	/* (t) Queue of IDLE threads. */
+	char		tdq_name[TDQ_NAME_LEN];
+#ifdef KTR
+	char		tdq_loadname[TDQ_LOADNAME_LEN];
+#endif
+};
+
+/* Idle thread states and config. */
+#define	TDQ_RUNNING	1
+#define	TDQ_IDLE	2
+
+/* Lockless accessors. */
+#define	TDQ_LOAD(tdq)		atomic_load_int(&(tdq)->tdq_load)
+#define	TDQ_TRANSFERABLE(tdq)	atomic_load_int(&(tdq)->tdq_transferable)
+#define	TDQ_SWITCHCNT(tdq)	(atomic_load_short(&(tdq)->tdq_switchcnt) + \
+				 atomic_load_short(&(tdq)->tdq_oldswitchcnt))
+#define	TDQ_SWITCHCNT_INC(tdq)	(atomic_store_short(&(tdq)->tdq_switchcnt, \
+				 atomic_load_short(&(tdq)->tdq_switchcnt) + 1))
+
+#ifdef SMP
+struct cpu_group __read_mostly *cpu_top;		/* CPU topology */
+
+#define	SCHED_AFFINITY_DEFAULT	(max(1, hz / 1000))
+#define	SCHED_AFFINITY(ts, t)	((ts)->ts_rltick > ticks - ((t) * affinity))
+
+/*
+ * Run-time tunables.
+ */
+static int rebalance = 1;
+static int balance_interval = 128;	/* Default set in sched_initticks(). */
+static int __read_mostly affinity;
+static int __read_mostly steal_idle = 1;
+static int __read_mostly steal_thresh = 2;
+static int __read_mostly always_steal = 0;
+static int __read_mostly trysteal_limit = 2;
+
+/*
+ * Hybrid-core (SCHED_MIC) placement tunables.  Weights are expressed on the
+ * same 256-points-per-thread scale used by the CPU search; they are folded
+ * into a candidate's load so that higher-priority core classes are filled
+ * first while work still spills to lower classes under real load (a soft,
+ * tunable preference).  The required per-candidate cost ordering is
+ *   idle perf (0) < idle eff < busy-sibling perf < idle LP.
+ */
+static int __read_mostly sched_class_weight_eff = 64;	/* class 2 penalty. */
+static int __read_mostly sched_class_weight_lp = 512;	/* class 4 penalty. */
+static int __read_mostly sched_smt_busy_penalty = 192;	/* busy-sibling (pri 3). */
+static int __read_mostly sched_prefer_compute = 0;	/* AMD X3D cache<->compute. */
+/* Read by machine-dependent classification; enables Intel LP-E detection. */
+int sched_detect_lpe = 1;
+
+/*
+ * Per-CPU core class, indexed by cpuid.  Defaults to CPU_CLASS_PERF for every
+ * CPU so that non-hybrid (and non-x86) systems behave exactly like SCHED_ULE.
+ * Populated by machine-dependent detection (see cpu_set_core_classes()).
+ */
+uint8_t cpu_core_class[MAXCPU] = { [0 ... MAXCPU - 1] = CPU_CLASS_PERF };
+
+/*
+ * One thread queue per processor.
+ */
+static struct tdq __read_mostly *balance_tdq;
+static int balance_ticks;
+DPCPU_DEFINE_STATIC(struct tdq, tdq);
+DPCPU_DEFINE_STATIC(uint32_t, randomval);
+
+#define	TDQ_SELF()	((struct tdq *)PCPU_GET(sched))
+#define	TDQ_CPU(x)	(DPCPU_ID_PTR((x), tdq))
+#define	TDQ_ID(x)	((x)->tdq_id)
+#else	/* !SMP */
+static struct tdq	tdq_cpu;
+
+#define	TDQ_ID(x)	(0)
+#define	TDQ_SELF()	(&tdq_cpu)
+#define	TDQ_CPU(x)	(&tdq_cpu)
+#endif
+
+#define	TDQ_LOCK_ASSERT(t, type)	mtx_assert(TDQ_LOCKPTR((t)), (type))
+#define	TDQ_LOCK(t)		mtx_lock_spin(TDQ_LOCKPTR((t)))
+#define	TDQ_LOCK_FLAGS(t, f)	mtx_lock_spin_flags(TDQ_LOCKPTR((t)), (f))
+#define	TDQ_TRYLOCK(t)		mtx_trylock_spin(TDQ_LOCKPTR((t)))
+#define	TDQ_TRYLOCK_FLAGS(t, f)	mtx_trylock_spin_flags(TDQ_LOCKPTR((t)), (f))
+#define	TDQ_UNLOCK(t)		mtx_unlock_spin(TDQ_LOCKPTR((t)))
+#define	TDQ_LOCKPTR(t)		((struct mtx *)(&(t)->tdq_lock))
+
+static void sched_setpreempt(int);
+static void sched_priority(struct thread *);
+static void sched_thread_priority(struct thread *, u_char);
+static int sched_interact_score(struct thread *);
+static void sched_interact_update(struct thread *);
+static void sched_interact_fork(struct thread *);
+static void sched_pctcpu_update(struct td_sched *, int);
+
+/* Operations on per processor queues */
+static struct thread *tdq_choose(struct tdq *);
+static void tdq_setup(struct tdq *, int i);
+static void tdq_load_add(struct tdq *, struct thread *);
+static void tdq_load_rem(struct tdq *, struct thread *);
+static __inline void tdq_runq_add(struct tdq *, struct thread *, int);
+static __inline void tdq_runq_rem(struct tdq *, struct thread *);
+static inline int sched_shouldpreempt(int, int, int);
+static void tdq_print(int cpu);
+static void runq_print(struct runq *rq);
+static int tdq_add(struct tdq *, struct thread *, int);
+#ifdef SMP
+static int tdq_move(struct tdq *, struct tdq *);
+static int tdq_idled(struct tdq *);
+static void tdq_notify(struct tdq *, int lowpri);
+static struct thread *tdq_steal(struct tdq *, int);
+static struct thread *runq_steal(struct runq *, int);
+static int sched_pickcpu(struct thread *, int);
+static void sched_balance(void);
+static bool sched_balance_pair(struct tdq *, struct tdq *);
+static inline struct tdq *sched_setcpu(struct thread *, int, int);
+static inline void thread_unblock_switch(struct thread *, struct mtx *);
+static int sysctl_kern_sched_topology_spec(SYSCTL_HANDLER_ARGS);
+static int sysctl_kern_sched_topology_spec_internal(struct sbuf *sb,
+    struct cpu_group *cg, int indent);
+static int sysctl_kern_sched_core_class(SYSCTL_HANDLER_ARGS);
+#endif
+
+static void sched_setup(void *dummy);
+SYSINIT(sched_setup, SI_SUB_RUN_QUEUE, SI_ORDER_FIRST, sched_setup, NULL);
+
+static void sched_initticks(void *dummy);
+SYSINIT(sched_initticks, SI_SUB_CLOCKS, SI_ORDER_THIRD, sched_initticks,
+    NULL);
+
+SDT_PROVIDER_DEFINE(sched);
+
+SDT_PROBE_DEFINE3(sched, , , change__pri, "struct thread *", 
+    "struct proc *", "uint8_t");
+SDT_PROBE_DEFINE3(sched, , , dequeue, "struct thread *", 
+    "struct proc *", "void *");
+SDT_PROBE_DEFINE4(sched, , , enqueue, "struct thread *", 
+    "struct proc *", "void *", "int");
+SDT_PROBE_DEFINE4(sched, , , lend__pri, "struct thread *", 
+    "struct proc *", "uint8_t", "struct thread *");
+SDT_PROBE_DEFINE2(sched, , , load__change, "int", "int");
+SDT_PROBE_DEFINE2(sched, , , off__cpu, "struct thread *", 
+    "struct proc *");
+SDT_PROBE_DEFINE(sched, , , on__cpu);
+SDT_PROBE_DEFINE(sched, , , remain__cpu);
+SDT_PROBE_DEFINE2(sched, , , surrender, "struct thread *", 
+    "struct proc *");
+
+/*
+ * Print the threads waiting on a run-queue.
+ */
+static void
+runq_print(struct runq *rq)
+{
+	struct rqhead *rqh;
+	struct thread *td;
+	int pri;
+	int j;
+	int i;
+
+	for (i = 0; i < RQB_LEN; i++) {
+		printf("\t\trunq bits %d 0x%zx\n",
+		    i, rq->rq_status.rqb_bits[i]);
+		for (j = 0; j < RQB_BPW; j++)
+			if (rq->rq_status.rqb_bits[i] & (1ul << j)) {
+				pri = j + (i << RQB_L2BPW);
+				rqh = &rq->rq_queues[pri];
+				TAILQ_FOREACH(td, rqh, td_runq) {
+					printf("\t\t\ttd %p(%s) priority %d rqindex %d pri %d\n",
+					    td, td->td_name, td->td_priority,
+					    td->td_rqindex, pri);
+				}
+			}
+	}
+}
+
+/*
+ * Print the status of a per-cpu thread queue.  Should be a ddb show cmd.
+ */
+static void __unused
+tdq_print(int cpu)
+{
+	struct tdq *tdq;
+
+	tdq = TDQ_CPU(cpu);
+
+	printf("tdq %d:\n", TDQ_ID(tdq));
+	printf("\tlock            %p\n", TDQ_LOCKPTR(tdq));
+	printf("\tLock name:      %s\n", tdq->tdq_name);
+	printf("\tload:           %d\n", tdq->tdq_load);
+	printf("\tswitch cnt:     %d\n", tdq->tdq_switchcnt);
+	printf("\told switch cnt: %d\n", tdq->tdq_oldswitchcnt);
+	printf("\ttimeshare idx:  %d\n", tdq->tdq_idx);
+	printf("\ttimeshare ridx: %d\n", tdq->tdq_ridx);
+	printf("\tload transferable: %d\n", tdq->tdq_transferable);
+	printf("\tlowest priority:   %d\n", tdq->tdq_lowpri);
+	printf("\trealtime runq:\n");
+	runq_print(&tdq->tdq_realtime);
+	printf("\ttimeshare runq:\n");
+	runq_print(&tdq->tdq_timeshare);
+	printf("\tidle runq:\n");
+	runq_print(&tdq->tdq_idle);
+}
+
+static inline int
+sched_shouldpreempt(int pri, int cpri, int remote)
+{
+	/*
+	 * If the new priority is not better than the current priority there is
+	 * nothing to do.
+	 */
+	if (pri >= cpri)
+		return (0);
+	/*
+	 * Always preempt idle.
+	 */
+	if (cpri >= PRI_MIN_IDLE)
+		return (1);
+	/*
+	 * If preemption is disabled don't preempt others.
+	 */
+	if (preempt_thresh == 0)
+		return (0);
+	/*
+	 * Preempt if we exceed the threshold.
+	 */
+	if (pri <= preempt_thresh)
+		return (1);
+	/*
+	 * If we're interactive or better and there is non-interactive
+	 * or worse running preempt only remote processors.
+	 */
+	if (remote && pri <= PRI_MAX_INTERACT && cpri > PRI_MAX_INTERACT)
+		return (1);
+	return (0);
+}
+
+/*
+ * Add a thread to the actual run-queue.  Keeps transferable counts up to
+ * date with what is actually on the run-queue.  Selects the correct
+ * queue position for timeshare threads.
+ */
+static __inline void
+tdq_runq_add(struct tdq *tdq, struct thread *td, int flags)
+{
+	struct td_sched *ts;
+	u_char pri;
+
+	TDQ_LOCK_ASSERT(tdq, MA_OWNED);
+	THREAD_LOCK_BLOCKED_ASSERT(td, MA_OWNED);
+
+	pri = td->td_priority;
+	ts = td_get_sched(td);
+	TD_SET_RUNQ(td);
+	if (THREAD_CAN_MIGRATE(td)) {
+		tdq->tdq_transferable++;
+		ts->ts_flags |= TSF_XFERABLE;
+	}
+	if (pri < PRI_MIN_BATCH) {
+		ts->ts_runq = &tdq->tdq_realtime;
+	} else if (pri <= PRI_MAX_BATCH) {
+		ts->ts_runq = &tdq->tdq_timeshare;
+		KASSERT(pri <= PRI_MAX_BATCH && pri >= PRI_MIN_BATCH,
+			("Invalid priority %d on timeshare runq", pri));
+		/*
+		 * This queue contains only priorities between MIN and MAX
+		 * batch.  Use the whole queue to represent these values.
+		 */
+		if ((flags & (SRQ_BORROWING|SRQ_PREEMPTED)) == 0) {
+			pri = RQ_NQS * (pri - PRI_MIN_BATCH) / PRI_BATCH_RANGE;
+			pri = (pri + tdq->tdq_idx) % RQ_NQS;
+			/*
+			 * This effectively shortens the queue by one so we
+			 * can have a one slot difference between idx and
+			 * ridx while we wait for threads to drain.
+			 */
+			if (tdq->tdq_ridx != tdq->tdq_idx &&
+			    pri == tdq->tdq_ridx)
+				pri = (unsigned char)(pri - 1) % RQ_NQS;
+		} else
+			pri = tdq->tdq_ridx;
+		runq_add_pri(ts->ts_runq, td, pri, flags);
+		return;
+	} else
+		ts->ts_runq = &tdq->tdq_idle;
+	runq_add(ts->ts_runq, td, flags);
+}
+
+/* 
+ * Remove a thread from a run-queue.  This typically happens when a thread
+ * is selected to run.  Running threads are not on the queue and the
+ * transferable count does not reflect them.
+ */
+static __inline void
+tdq_runq_rem(struct tdq *tdq, struct thread *td)
+{
+	struct td_sched *ts;
+
+	ts = td_get_sched(td);
+	TDQ_LOCK_ASSERT(tdq, MA_OWNED);
+	THREAD_LOCK_BLOCKED_ASSERT(td, MA_OWNED);
+	KASSERT(ts->ts_runq != NULL,
+	    ("tdq_runq_remove: thread %p null ts_runq", td));
+	if (ts->ts_flags & TSF_XFERABLE) {
+		tdq->tdq_transferable--;
+		ts->ts_flags &= ~TSF_XFERABLE;
+	}
+	if (ts->ts_runq == &tdq->tdq_timeshare) {
+		if (tdq->tdq_idx != tdq->tdq_ridx)
+			runq_remove_idx(ts->ts_runq, td, &tdq->tdq_ridx);
+		else
+			runq_remove_idx(ts->ts_runq, td, NULL);
+	} else
+		runq_remove(ts->ts_runq, td);
+}
+
+/*
+ * Load is maintained for all threads RUNNING and ON_RUNQ.  Add the load
+ * for this thread to the referenced thread queue.
+ */
+static void
+tdq_load_add(struct tdq *tdq, struct thread *td)
+{
+
+	TDQ_LOCK_ASSERT(tdq, MA_OWNED);
+	THREAD_LOCK_BLOCKED_ASSERT(td, MA_OWNED);
+
+	tdq->tdq_load++;
+	if ((td->td_flags & TDF_NOLOAD) == 0)
+		tdq->tdq_sysload++;
+	KTR_COUNTER0(KTR_SCHED, "load", tdq->tdq_loadname, tdq->tdq_load);
+	SDT_PROBE2(sched, , , load__change, (int)TDQ_ID(tdq), tdq->tdq_load);
+}
+
+/*
+ * Remove the load from a thread that is transitioning to a sleep state or
+ * exiting.
+ */
+static void
+tdq_load_rem(struct tdq *tdq, struct thread *td)
+{
+
+	TDQ_LOCK_ASSERT(tdq, MA_OWNED);
+	THREAD_LOCK_BLOCKED_ASSERT(td, MA_OWNED);
+	KASSERT(tdq->tdq_load != 0,
+	    ("tdq_load_rem: Removing with 0 load on queue %d", TDQ_ID(tdq)));
+
+	tdq->tdq_load--;
+	if ((td->td_flags & TDF_NOLOAD) == 0)
+		tdq->tdq_sysload--;
+	KTR_COUNTER0(KTR_SCHED, "load", tdq->tdq_loadname, tdq->tdq_load);
+	SDT_PROBE2(sched, , , load__change, (int)TDQ_ID(tdq), tdq->tdq_load);
+}
+
+/*
+ * Bound timeshare latency by decreasing slice size as load increases.  We
+ * consider the maximum latency as the sum of the threads waiting to run
+ * aside from curthread and target no more than sched_slice latency but
+ * no less than sched_slice_min runtime.
+ */
+static inline int
+tdq_slice(struct tdq *tdq)
+{
+	int load;
+
+	/*
+	 * It is safe to use sys_load here because this is called from
+	 * contexts where timeshare threads are running and so there
+	 * cannot be higher priority load in the system.
+	 */
+	load = tdq->tdq_sysload - 1;
+	if (load >= SCHED_SLICE_MIN_DIVISOR)
+		return (sched_slice_min);
+	if (load <= 1)
+		return (sched_slice);
+	return (sched_slice / load);
+}
+
+/*
+ * Set lowpri to its exact value by searching the run-queue and
+ * evaluating curthread.  curthread may be passed as an optimization.
+ */
+static void
+tdq_setlowpri(struct tdq *tdq, struct thread *ctd)
+{
+	struct thread *td;
+
+	TDQ_LOCK_ASSERT(tdq, MA_OWNED);
+	if (ctd == NULL)
+		ctd = tdq->tdq_curthread;
+	td = tdq_choose(tdq);
+	if (td == NULL || td->td_priority > ctd->td_priority)
+		tdq->tdq_lowpri = ctd->td_priority;
+	else
+		tdq->tdq_lowpri = td->td_priority;
+}
+
+#ifdef SMP
+/*
+ * We need some randomness. Implement a classic Linear Congruential
+ * Generator X_{n+1}=(aX_n+c) mod m. These values are optimized for
+ * m = 2^32, a = 69069 and c = 5. We only return the upper 16 bits
+ * of the random state (in the low bits of our answer) to keep
+ * the maximum randomness.
+ */
+static uint32_t
+sched_random(void)
+{
+	uint32_t *rndptr;
+
+	rndptr = DPCPU_PTR(randomval);
+	*rndptr = *rndptr * 69069 + 5;
+
+	return (*rndptr >> 16);
+}
+
+struct cpu_search {
+	cpuset_t *cs_mask;	/* The mask of allowed CPUs to choose from. */
+	int	cs_prefer;	/* Prefer this CPU and groups including it. */
+	int	cs_running;	/* The thread is now running at cs_prefer. */
+	int	cs_pri;		/* Min priority for low. */
+	int	cs_load;	/* Max load for low, min load for high. */
+	int	cs_trans;	/* Min transferable load for high. */
+	int	cs_class;	/* Apply hybrid-core class cost (placement). */
+};
+
+struct cpu_search_res {
+	int	csr_cpu;	/* The best CPU found. */
+	int	csr_load;	/* The load of cs_cpu. */
+};
+
+/*
+ * Return true if any SMT sibling of CPU "self" within leaf group "cg" is
+ * carrying load.  Used to deprioritize a busy core's free thread (the
+ * dynamic "priority 3") relative to an idle efficiency core.
+ */
+static bool
+smt_sibling_busy(const struct cpu_group *cg, int self)
+{
+	int s;
+
+	for (s = cg->cg_first; s <= cg->cg_last; s++)
+		if (s != self && CPU_ISSET(s, &cg->cg_mask) &&
+		    TDQ_LOAD(TDQ_CPU(s)) > 0)
+			return (true);
+	return (false);
+}
+
+/*
+ * Compute the hybrid-core placement cost added to a candidate CPU's load.
+ * Returns 0 for performance-class CPUs with no busy SMT sibling, so on
+ * homogeneous hardware (all CPU_CLASS_PERF) the search is identical to ULE.
+ * The result is folded into "load" before it is summed into the per-group
+ * total, so the bias steers both subtree selection and the final CPU pick.
+ */
+static int
+sched_class_cost(const struct cpu_group *cg, int c, int l)
+{
+	int cls, cost;
+
+	cls = cpu_core_class[c];
+	if (sched_prefer_compute) {		/* AMD X3D: cache <-> compute. */
+		if (cls == CPU_CLASS_PERF)
+			cls = CPU_CLASS_EFF;
+		else if (cls == CPU_CLASS_EFF)
+			cls = CPU_CLASS_PERF;
+	}
+	if (cls == CPU_CLASS_EFF)
+		cost = sched_class_weight_eff;
+	else if (cls == CPU_CLASS_LP)
+		cost = sched_class_weight_lp;
+	else
+		cost = 0;
+
+	/*
+	 * Priority 3: a free thread whose SMT sibling is busy.  Applied to any
+	 * threaded core (LP-E cores are not threaded) and unconditionally,
+	 * unlike the cs_running-only penalty in cpu_search_lowest(), so it also
+	 * influences initial placement.  Stacks on the class cost so the fill
+	 * order is idle perf -> idle eff -> busy-sibling perf -> busy-sibling
+	 * eff -> idle LP.
+	 */
+	if (l == 0 && (cg->cg_flags & CG_FLAG_THREAD) && smt_sibling_busy(cg, c))
+		cost += sched_smt_busy_penalty;
+	return (cost);
+}
+
+/*
+ * Search the tree of cpu_groups for the lowest or highest loaded CPU.
+ * These routines actually compare the load on all paths through the tree
+ * and find the least loaded cpu on the least loaded path, which may differ
+ * from the least loaded cpu in the system.  This balances work among caches
+ * and buses.
+ */
+static int
+cpu_search_lowest(const struct cpu_group *cg, const struct cpu_search *s,
+    struct cpu_search_res *r)
+{
+	struct cpu_search_res lr;
+	struct tdq *tdq;
+	int c, bload, l, load, p, total;
+
+	total = 0;
+	bload = INT_MAX;
+	r->csr_cpu = -1;
+
+	/* Loop through children CPU groups if there are any. */
+	if (cg->cg_children > 0) {
+		for (c = cg->cg_children - 1; c >= 0; c--) {
+			load = cpu_search_lowest(&cg->cg_child[c], s, &lr);
+			total += load;
+
+			/*
+			 * When balancing do not prefer SMT groups with load >1.
+			 * It allows round-robin between SMT groups with equal
+			 * load within parent group for more fair scheduling.
+			 */
+			if (__predict_false(s->cs_running) &&
+			    (cg->cg_child[c].cg_flags & CG_FLAG_THREAD) &&
+			    load >= 128 && (load & 128) != 0)
+				load += 128;
+
+			if (lr.csr_cpu >= 0 && (load < bload ||
+			    (load == bload && lr.csr_load < r->csr_load))) {
+				bload = load;
+				r->csr_cpu = lr.csr_cpu;
+				r->csr_load = lr.csr_load;
+			}
+		}
+		return (total);
+	}
+
+	/* Loop through children CPUs otherwise. */
+	for (c = cg->cg_last; c >= cg->cg_first; c--) {
+		if (!CPU_ISSET(c, &cg->cg_mask))
+			continue;
+		tdq = TDQ_CPU(c);
+		l = TDQ_LOAD(tdq);
+		if (c == s->cs_prefer) {
+			if (__predict_false(s->cs_running))
+				l--;
+			p = 128;
+		} else
+			p = 0;
+		/*
+		 * Fold the hybrid-core class cost into this candidate's load
+		 * before it is summed into the group total, so the bias steers
+		 * both subtree selection and the final CPU choice.
+		 */
+		load = l * 256;
+		if (s->cs_class)
+			load += sched_class_cost(cg, c, l);
+		total += load - p;
+
+		/*
+		 * Check this CPU is acceptable.
+		 * If the threads is already on the CPU, don't look on the TDQ
+		 * priority, since it can be the priority of the thread itself.
+		 */
+		if (l > s->cs_load ||
+		    (atomic_load_char(&tdq->tdq_lowpri) <= s->cs_pri &&
+		     (!s->cs_running || c != s->cs_prefer)) ||
+		    !CPU_ISSET(c, s->cs_mask))
+			continue;
+
+		/*
+		 * When balancing do not prefer CPUs with load > 1.
+		 * It allows round-robin between CPUs with equal load
+		 * within the CPU group for more fair scheduling.
+		 */
+		if (__predict_false(s->cs_running) && l > 0)
+			p = 0;
+
+		load -= sched_random() % 128;
+		if (bload > load - p) {
+			bload = load - p;
+			r->csr_cpu = c;
+			r->csr_load = load;
+		}
+	}
+	return (total);
+}
+
+static int
+cpu_search_highest(const struct cpu_group *cg, const struct cpu_search *s,
+    struct cpu_search_res *r)
+{
+	struct cpu_search_res lr;
+	struct tdq *tdq;
+	int c, bload, l, load, total;
+
+	total = 0;
+	bload = INT_MIN;
+	r->csr_cpu = -1;
+
+	/* Loop through children CPU groups if there are any. */
+	if (cg->cg_children > 0) {
+		for (c = cg->cg_children - 1; c >= 0; c--) {
+			load = cpu_search_highest(&cg->cg_child[c], s, &lr);
+			total += load;
+			if (lr.csr_cpu >= 0 && (load > bload ||
+			    (load == bload && lr.csr_load > r->csr_load))) {
+				bload = load;
+				r->csr_cpu = lr.csr_cpu;
+				r->csr_load = lr.csr_load;
+			}
+		}
+		return (total);
+	}
+
+	/* Loop through children CPUs otherwise. */
+	for (c = cg->cg_last; c >= cg->cg_first; c--) {
+		if (!CPU_ISSET(c, &cg->cg_mask))
+			continue;
+		tdq = TDQ_CPU(c);
+		l = TDQ_LOAD(tdq);
+		load = l * 256;
+		total += load;
+
+		/*
+		 * Check this CPU is acceptable.
+		 */
+		if (l < s->cs_load || TDQ_TRANSFERABLE(tdq) < s->cs_trans ||
+		    !CPU_ISSET(c, s->cs_mask))
+			continue;
+
+		load -= sched_random() % 256;
+		if (load > bload) {
+			bload = load;
+			r->csr_cpu = c;
+		}
+	}
+	r->csr_load = bload;
+	return (total);
+}
+
+/*
+ * Find the cpu with the least load via the least loaded path that has a
+ * lowpri greater than pri  pri.  A pri of -1 indicates any priority is
+ * acceptable.
+ */
+static inline int
+sched_lowest(const struct cpu_group *cg, cpuset_t *mask, int pri, int maxload,
+    int prefer, int running, int class_aware)
+{
+	struct cpu_search s;
+	struct cpu_search_res r;
+
+	s.cs_prefer = prefer;
+	s.cs_running = running;
+	s.cs_mask = mask;
+	s.cs_pri = pri;
+	s.cs_load = maxload;
+	s.cs_class = class_aware;
+	cpu_search_lowest(cg, &s, &r);
+	return (r.csr_cpu);
+}
+
+/*
+ * Find the cpu with the highest load via the highest loaded path.
+ */
+static inline int
+sched_highest(const struct cpu_group *cg, cpuset_t *mask, int minload,
+    int mintrans)
+{
+	struct cpu_search s;
+	struct cpu_search_res r;
+
+	s.cs_mask = mask;
+	s.cs_load = minload;
+	s.cs_trans = mintrans;
+	cpu_search_highest(cg, &s, &r);
+	return (r.csr_cpu);
+}
+
+static void
+sched_balance_group(struct cpu_group *cg)
+{
+	struct tdq *tdq;
+	struct thread *td;
+	cpuset_t hmask, lmask;
+	int high, low, anylow;
+
+	CPU_FILL(&hmask);
+	for (;;) {
+		high = sched_highest(cg, &hmask, 1, 0);
+		/* Stop if there is no more CPU with transferrable threads. */
+		if (high == -1)
+			break;
+		CPU_CLR(high, &hmask);
+		CPU_COPY(&hmask, &lmask);
+		/* Stop if there is no more CPU left for low. */
+		if (CPU_EMPTY(&lmask))
+			break;
+		tdq = TDQ_CPU(high);
+		if (TDQ_LOAD(tdq) == 1) {
+			/*
+			 * There is only one running thread.  We can't move
+			 * it from here, so tell it to pick new CPU by itself.
+			 */
+			TDQ_LOCK(tdq);
+			td = tdq->tdq_curthread;
+			if (td->td_lock == TDQ_LOCKPTR(tdq) &&
+			    (td->td_flags & TDF_IDLETD) == 0 &&
+			    THREAD_CAN_MIGRATE(td)) {
+				td->td_flags |= TDF_NEEDRESCHED | TDF_PICKCPU;
+				if (high != curcpu)
+					ipi_cpu(high, IPI_AST);
+			}
+			TDQ_UNLOCK(tdq);
+			break;
+		}
+		anylow = 1;
+nextlow:
+		if (TDQ_TRANSFERABLE(tdq) == 0)
+			continue;
+		low = sched_lowest(cg, &lmask, -1, TDQ_LOAD(tdq) - 1, high, 1, 0);
+		/* Stop if we looked well and found no less loaded CPU. */
+		if (anylow && low == -1)
+			break;
+		/* Go to next high if we found no less loaded CPU. */
+		if (low == -1)
+			continue;
+		/* Transfer thread from high to low. */
+		if (sched_balance_pair(tdq, TDQ_CPU(low))) {
+			/* CPU that got thread can no longer be a donor. */
+			CPU_CLR(low, &hmask);
+		} else {
+			/*
+			 * If failed, then there is no threads on high
+			 * that can run on this low. Drop low from low
+			 * mask and look for different one.
+			 */
+			CPU_CLR(low, &lmask);
+			anylow = 0;
+			goto nextlow;
+		}
+	}
+}
+
+static void
+sched_balance(void)
+{
+	struct tdq *tdq;
+
+	balance_ticks = max(balance_interval / 2, 1) +
+	    (sched_random() % balance_interval);
+	tdq = TDQ_SELF();
+	TDQ_UNLOCK(tdq);
+	sched_balance_group(cpu_top);
+	TDQ_LOCK(tdq);
+}
+
+/*
+ * Lock two thread queues using their address to maintain lock order.
+ */
+static void
+tdq_lock_pair(struct tdq *one, struct tdq *two)
+{
+	if (one < two) {
+		TDQ_LOCK(one);
+		TDQ_LOCK_FLAGS(two, MTX_DUPOK);
+	} else {
+		TDQ_LOCK(two);
+		TDQ_LOCK_FLAGS(one, MTX_DUPOK);
+	}
+}
+
+/*
+ * Unlock two thread queues.  Order is not important here.
+ */
+static void
+tdq_unlock_pair(struct tdq *one, struct tdq *two)
+{
+	TDQ_UNLOCK(one);
+	TDQ_UNLOCK(two);
+}
+
+/*
+ * Transfer load between two imbalanced thread queues.  Returns true if a thread
+ * was moved between the queues, and false otherwise.
+ */
+static bool
+sched_balance_pair(struct tdq *high, struct tdq *low)
+{
+	int cpu, lowpri;
+	bool ret;
+
+	ret = false;
+	tdq_lock_pair(high, low);
+
+	/*
+	 * Transfer a thread from high to low.
+	 */
+	if (high->tdq_transferable != 0 && high->tdq_load > low->tdq_load) {
+		lowpri = tdq_move(high, low);
+		if (lowpri != -1) {
+			/*
+			 * In case the target isn't the current CPU notify it of
+			 * the new load, possibly sending an IPI to force it to
+			 * reschedule.  Otherwise maybe schedule a preemption.
+			 */
+			cpu = TDQ_ID(low);
+			if (cpu != PCPU_GET(cpuid))
+				tdq_notify(low, lowpri);
+			else
+				sched_setpreempt(low->tdq_lowpri);
+			ret = true;
+		}
+	}
+	tdq_unlock_pair(high, low);
+	return (ret);
+}
+
+/*
+ * Move a thread from one thread queue to another.  Returns -1 if the source
+ * queue was empty, else returns the maximum priority of all threads in
+ * the destination queue prior to the addition of the new thread.  In the latter
+ * case, this priority can be used to determine whether an IPI needs to be
+ * delivered.
+ */
+static int
+tdq_move(struct tdq *from, struct tdq *to)
+{
+	struct thread *td;
+	int cpu;
+
+	TDQ_LOCK_ASSERT(from, MA_OWNED);
+	TDQ_LOCK_ASSERT(to, MA_OWNED);
+
+	cpu = TDQ_ID(to);
+	td = tdq_steal(from, cpu);
+	if (td == NULL)
+		return (-1);
+
+	/*
+	 * Although the run queue is locked the thread may be
+	 * blocked.  We can not set the lock until it is unblocked.
+	 */
+	thread_lock_block_wait(td);
+	sched_rem(td);
+	THREAD_LOCKPTR_ASSERT(td, TDQ_LOCKPTR(from));
+	td->td_lock = TDQ_LOCKPTR(to);
+	td_get_sched(td)->ts_cpu = cpu;
+	return (tdq_add(to, td, SRQ_YIELDING));
+}
+
+/*
+ * This tdq has idled.  Try to steal a thread from another cpu and switch
+ * to it.
+ */
+static int
+tdq_idled(struct tdq *tdq)
+{
+	struct cpu_group *cg, *parent;
+	struct tdq *steal;
+	cpuset_t mask;
+	int cpu, switchcnt, goup;
+
+	if (smp_started == 0 || steal_idle == 0 || tdq->tdq_cg == NULL)
+		return (1);
+	CPU_FILL(&mask);
+	CPU_CLR(PCPU_GET(cpuid), &mask);
+restart:
+	switchcnt = TDQ_SWITCHCNT(tdq);
+	for (cg = tdq->tdq_cg, goup = 0; ; ) {
+		cpu = sched_highest(cg, &mask, steal_thresh, 1);
+		/*
+		 * We were assigned a thread but not preempted.  Returning
+		 * 0 here will cause our caller to switch to it.
+		 */
+		if (TDQ_LOAD(tdq))
+			return (0);
+
+		/*
+		 * We found no CPU to steal from in this group.  Escalate to
+		 * the parent and repeat.  But if parent has only two children
+		 * groups we can avoid searching this group again by searching
+		 * the other one specifically and then escalating two levels.
+		 */
+		if (cpu == -1) {
+			if (goup) {
+				cg = cg->cg_parent;
+				goup = 0;
+			}
+			parent = cg->cg_parent;
+			if (parent == NULL)
+				return (1);
+			if (parent->cg_children == 2) {
+				if (cg == &parent->cg_child[0])
+					cg = &parent->cg_child[1];
+				else
+					cg = &parent->cg_child[0];
+				goup = 1;
+			} else
+				cg = parent;
+			continue;
+		}
+		steal = TDQ_CPU(cpu);
+		/*
+		 * The data returned by sched_highest() is stale and
+		 * the chosen CPU no longer has an eligible thread.
+		 *
+		 * Testing this ahead of tdq_lock_pair() only catches
+		 * this situation about 20% of the time on an 8 core
+		 * 16 thread Ryzen 7, but it still helps performance.
+		 */
+		if (TDQ_LOAD(steal) < steal_thresh ||
+		    TDQ_TRANSFERABLE(steal) == 0)
+			goto restart;
+		/*
+		 * Try to lock both queues. If we are assigned a thread while
+		 * waited for the lock, switch to it now instead of stealing.
+		 * If we can't get the lock, then somebody likely got there
+		 * first so continue searching.
+		 */
+		TDQ_LOCK(tdq);
+		if (tdq->tdq_load > 0) {
+			mi_switch(SW_VOL | SWT_IDLE);
+			return (0);
+		}
+		if (TDQ_TRYLOCK_FLAGS(steal, MTX_DUPOK) == 0) {
+			TDQ_UNLOCK(tdq);
+			CPU_CLR(cpu, &mask);
+			continue;
+		}
+		/*
+		 * The data returned by sched_highest() is stale and
+		 * the chosen CPU no longer has an eligible thread, or
+		 * we were preempted and the CPU loading info may be out
+		 * of date.  The latter is rare.  In either case restart
+		 * the search.
+		 */
+		if (TDQ_LOAD(steal) < steal_thresh ||
+		    TDQ_TRANSFERABLE(steal) == 0 ||
+		    switchcnt != TDQ_SWITCHCNT(tdq)) {
+			tdq_unlock_pair(tdq, steal);
+			goto restart;
+		}
+		/*
+		 * Steal the thread and switch to it.
+		 */
+		if (tdq_move(steal, tdq) != -1)
+			break;
+		/*
+		 * We failed to acquire a thread even though it looked
+		 * like one was available.  This could be due to affinity
+		 * restrictions or for other reasons.  Loop again after
+		 * removing this CPU from the set.  The restart logic
+		 * above does not restore this CPU to the set due to the
+		 * likelyhood of failing here again.
+		 */
+		CPU_CLR(cpu, &mask);
+		tdq_unlock_pair(tdq, steal);
+	}
+	TDQ_UNLOCK(steal);
+	mi_switch(SW_VOL | SWT_IDLE);
+	return (0);
+}
+
+/*
+ * Notify a remote cpu of new work.  Sends an IPI if criteria are met.
+ *
+ * "lowpri" is the minimum scheduling priority among all threads on
+ * the queue prior to the addition of the new thread.
+ */
+static void
+tdq_notify(struct tdq *tdq, int lowpri)
+{
+	int cpu;
+
+	TDQ_LOCK_ASSERT(tdq, MA_OWNED);
+	KASSERT(tdq->tdq_lowpri <= lowpri,
+	    ("tdq_notify: lowpri %d > tdq_lowpri %d", lowpri, tdq->tdq_lowpri));
+
+	if (tdq->tdq_owepreempt)
+		return;
+
+	/*
+	 * Check to see if the newly added thread should preempt the one
+	 * currently running.
+	 */
+	if (!sched_shouldpreempt(tdq->tdq_lowpri, lowpri, 1))
+		return;
+
+	/*
+	 * Make sure that our caller's earlier update to tdq_load is
+	 * globally visible before we read tdq_cpu_idle.  Idle thread
+	 * accesses both of them without locks, and the order is important.
+	 */
+	atomic_thread_fence_seq_cst();
+
+	/*
+	 * Try to figure out if we can signal the idle thread instead of sending
+	 * an IPI.  This check is racy; at worst, we will deliever an IPI
+	 * unnecessarily.
+	 */
+	cpu = TDQ_ID(tdq);
+	if (TD_IS_IDLETHREAD(tdq->tdq_curthread) &&
+	    (atomic_load_int(&tdq->tdq_cpu_idle) == 0 || cpu_idle_wakeup(cpu)))
+		return;
+
+	/*
+	 * The run queues have been updated, so any switch on the remote CPU
+	 * will satisfy the preemption request.
+	 */
+	tdq->tdq_owepreempt = 1;
+	ipi_cpu(cpu, IPI_PREEMPT);
+}
+
+/*
+ * Steals load from a timeshare queue.  Honors the rotating queue head
+ * index.
+ */
+static struct thread *
+runq_steal_from(struct runq *rq, int cpu, u_char start)
+{
+	struct rqbits *rqb;
+	struct rqhead *rqh;
+	struct thread *td, *first;
+	int bit;
+	int i;
+
+	rqb = &rq->rq_status;
+	bit = start & (RQB_BPW -1);
+	first = NULL;
+again:
+	for (i = RQB_WORD(start); i < RQB_LEN; bit = 0, i++) {
+		if (rqb->rqb_bits[i] == 0)
+			continue;
+		if (bit == 0)
+			bit = RQB_FFS(rqb->rqb_bits[i]);
+		for (; bit < RQB_BPW; bit++) {
+			if ((rqb->rqb_bits[i] & (1ul << bit)) == 0)
+				continue;
+			rqh = &rq->rq_queues[bit + (i << RQB_L2BPW)];
+			TAILQ_FOREACH(td, rqh, td_runq) {
+				if (first) {
+					if (THREAD_CAN_MIGRATE(td) &&
+					    THREAD_CAN_SCHED(td, cpu))
+						return (td);
+				} else
+					first = td;
+			}
+		}
+	}
+	if (start != 0) {
+		start = 0;
+		goto again;
+	}
+
+	if (first && THREAD_CAN_MIGRATE(first) &&
+	    THREAD_CAN_SCHED(first, cpu))
+		return (first);
+	return (NULL);
+}
+
+/*
+ * Steals load from a standard linear queue.
+ */
+static struct thread *
+runq_steal(struct runq *rq, int cpu)
+{
+	struct rqhead *rqh;
+	struct rqbits *rqb;
+	struct thread *td;
+	int word;
+	int bit;
+
+	rqb = &rq->rq_status;
+	for (word = 0; word < RQB_LEN; word++) {
+		if (rqb->rqb_bits[word] == 0)
+			continue;
+		for (bit = 0; bit < RQB_BPW; bit++) {
+			if ((rqb->rqb_bits[word] & (1ul << bit)) == 0)
+				continue;
+			rqh = &rq->rq_queues[bit + (word << RQB_L2BPW)];
+			TAILQ_FOREACH(td, rqh, td_runq)
+				if (THREAD_CAN_MIGRATE(td) &&
+				    THREAD_CAN_SCHED(td, cpu))
+					return (td);
+		}
+	}
+	return (NULL);
+}
+
+/*
+ * Attempt to steal a thread in priority order from a thread queue.
+ */
+static struct thread *
+tdq_steal(struct tdq *tdq, int cpu)
+{
+	struct thread *td;
+
+	TDQ_LOCK_ASSERT(tdq, MA_OWNED);
+	if ((td = runq_steal(&tdq->tdq_realtime, cpu)) != NULL)
+		return (td);
+	if ((td = runq_steal_from(&tdq->tdq_timeshare,
+	    cpu, tdq->tdq_ridx)) != NULL)
+		return (td);
+	return (runq_steal(&tdq->tdq_idle, cpu));
+}
+
+/*
+ * Sets the thread lock and ts_cpu to match the requested cpu.  Unlocks the
+ * current lock and returns with the assigned queue locked.
+ */
+static inline struct tdq *
+sched_setcpu(struct thread *td, int cpu, int flags)
+{
+
+	struct tdq *tdq;
+	struct mtx *mtx;
+
+	THREAD_LOCK_ASSERT(td, MA_OWNED);
+	tdq = TDQ_CPU(cpu);
+	td_get_sched(td)->ts_cpu = cpu;
+	/*
+	 * If the lock matches just return the queue.
+	 */
+	if (td->td_lock == TDQ_LOCKPTR(tdq)) {
+		KASSERT((flags & SRQ_HOLD) == 0,
+		    ("sched_setcpu: Invalid lock for SRQ_HOLD"));
+		return (tdq);
+	}
+
+	/*
+	 * The hard case, migration, we need to block the thread first to
+	 * prevent order reversals with other cpus locks.
+	 */
+	spinlock_enter();
+	mtx = thread_lock_block(td);
+	if ((flags & SRQ_HOLD) == 0)
+		mtx_unlock_spin(mtx);
+	TDQ_LOCK(tdq);
+	thread_lock_unblock(td, TDQ_LOCKPTR(tdq));
+	spinlock_exit();
+	return (tdq);
+}
+
+SCHED_STAT_DEFINE(pickcpu_intrbind, "Soft interrupt binding");
+SCHED_STAT_DEFINE(pickcpu_idle_affinity, "Picked idle cpu based on affinity");
+SCHED_STAT_DEFINE(pickcpu_affinity, "Picked cpu based on affinity");
+SCHED_STAT_DEFINE(pickcpu_lowest, "Selected lowest load");
+SCHED_STAT_DEFINE(pickcpu_local, "Migrated to current cpu");
+SCHED_STAT_DEFINE(pickcpu_migration, "Selection may have caused migration");
+
+static int
+sched_pickcpu(struct thread *td, int flags)
+{
+	struct cpu_group *cg, *ccg;
+	struct td_sched *ts;
+	struct tdq *tdq;
+	cpuset_t *mask;
+	int cpu, pri, r, self, intr;
+
+	self = PCPU_GET(cpuid);
+	ts = td_get_sched(td);
+	KASSERT(!CPU_ABSENT(ts->ts_cpu), ("sched_pickcpu: Start scheduler on "
+	    "absent CPU %d for thread %s.", ts->ts_cpu, td->td_name));
+	if (smp_started == 0)
+		return (self);
+	/*
+	 * Don't migrate a running thread from sched_switch().
+	 */
+	if ((flags & SRQ_OURSELF) || !THREAD_CAN_MIGRATE(td))
+		return (ts->ts_cpu);
+	/*
+	 * Prefer to run interrupt threads on the processors that generate
+	 * the interrupt.
+	 */
+	if (td->td_priority <= PRI_MAX_ITHD && THREAD_CAN_SCHED(td, self) &&
+	    curthread->td_intr_nesting_level) {
+		tdq = TDQ_SELF();
+		if (tdq->tdq_lowpri >= PRI_MIN_IDLE) {
+			SCHED_STAT_INC(pickcpu_idle_affinity);
+			return (self);
+		}
+		ts->ts_cpu = self;
+		intr = 1;
+		cg = tdq->tdq_cg;
+		goto llc;
+	} else {
+		intr = 0;
+		tdq = TDQ_CPU(ts->ts_cpu);
+		cg = tdq->tdq_cg;
+	}
+	/*
+	 * If the thread can run on the last cpu and the affinity has not
+	 * expired and it is idle, run it there.
+	 */
+	if (THREAD_CAN_SCHED(td, ts->ts_cpu) &&
+	    atomic_load_char(&tdq->tdq_lowpri) >= PRI_MIN_IDLE &&
+	    SCHED_AFFINITY(ts, CG_SHARE_L2)) {
+		if (cg->cg_flags & CG_FLAG_THREAD) {
+			/* Check all SMT threads for being idle. */
+			for (cpu = cg->cg_first; cpu <= cg->cg_last; cpu++) {
+				pri =
+				    atomic_load_char(&TDQ_CPU(cpu)->tdq_lowpri);
+				if (CPU_ISSET(cpu, &cg->cg_mask) &&
+				    pri < PRI_MIN_IDLE)
+					break;
+			}
+			if (cpu > cg->cg_last) {
+				SCHED_STAT_INC(pickcpu_idle_affinity);
+				return (ts->ts_cpu);
+			}
+		} else {
+			SCHED_STAT_INC(pickcpu_idle_affinity);
+			return (ts->ts_cpu);
+		}
+	}
+llc:
+	/*
+	 * Search for the last level cache CPU group in the tree.
+	 * Skip SMT, identical groups and caches with expired affinity.
+	 * Interrupt threads affinity is explicit and never expires.
+	 */
+	for (ccg = NULL; cg != NULL; cg = cg->cg_parent) {
+		if (cg->cg_flags & CG_FLAG_THREAD)
+			continue;
+		if (cg->cg_children == 1 || cg->cg_count == 1)
+			continue;
+		if (cg->cg_level == CG_SHARE_NONE ||
+		    (!intr && !SCHED_AFFINITY(ts, cg->cg_level)))
+			continue;
+		ccg = cg;
+	}
+	/* Found LLC shared by all CPUs, so do a global search. */
+	if (ccg == cpu_top)
+		ccg = NULL;
+	cpu = -1;
+	mask = &td->td_cpuset->cs_mask;
+	pri = td->td_priority;
+	r = TD_IS_RUNNING(td);
+	/*
+	 * Try hard to keep interrupts within found LLC.  Search the LLC for
+	 * the least loaded CPU we can run now.  For NUMA systems it should
+	 * be within target domain, and it also reduces scheduling overhead.
+	 */
+	if (ccg != NULL && intr) {
+		cpu = sched_lowest(ccg, mask, pri, INT_MAX, ts->ts_cpu, r, 1);
+		if (cpu >= 0)
+			SCHED_STAT_INC(pickcpu_intrbind);
+	} else
+	/* Search the LLC for the least loaded idle CPU we can run now. */
+	if (ccg != NULL) {
+		cpu = sched_lowest(ccg, mask, max(pri, PRI_MAX_TIMESHARE),
+		    INT_MAX, ts->ts_cpu, r, 1);
+		if (cpu >= 0)
+			SCHED_STAT_INC(pickcpu_affinity);
+	}
+	/* Search globally for the least loaded CPU we can run now. */
+	if (cpu < 0) {
+		cpu = sched_lowest(cpu_top, mask, pri, INT_MAX, ts->ts_cpu, r, 1);
+		if (cpu >= 0)
+			SCHED_STAT_INC(pickcpu_lowest);
+	}
+	/* Search globally for the least loaded CPU. */
+	if (cpu < 0) {
+		cpu = sched_lowest(cpu_top, mask, -1, INT_MAX, ts->ts_cpu, r, 1);
+		if (cpu >= 0)
+			SCHED_STAT_INC(pickcpu_lowest);
+	}
+	KASSERT(cpu >= 0, ("sched_pickcpu: Failed to find a cpu."));
+	KASSERT(!CPU_ABSENT(cpu), ("sched_pickcpu: Picked absent CPU %d.", cpu));
+	/*
+	 * Compare the lowest loaded cpu to current cpu.
+	 */
+	tdq = TDQ_CPU(cpu);
+	if (THREAD_CAN_SCHED(td, self) && TDQ_SELF()->tdq_lowpri > pri &&
+	    atomic_load_char(&tdq->tdq_lowpri) < PRI_MIN_IDLE &&
+	    TDQ_LOAD(TDQ_SELF()) <= TDQ_LOAD(tdq) + 1) {
+		SCHED_STAT_INC(pickcpu_local);
+		cpu = self;
+	}
+	if (cpu != ts->ts_cpu)
+		SCHED_STAT_INC(pickcpu_migration);
+	return (cpu);
+}
+#endif
+
+/*
+ * Pick the highest priority task we have and return it.
+ */
+static struct thread *
+tdq_choose(struct tdq *tdq)
+{
+	struct thread *td;
+
+	TDQ_LOCK_ASSERT(tdq, MA_OWNED);
+	td = runq_choose(&tdq->tdq_realtime);
+	if (td != NULL)
+		return (td);
+	td = runq_choose_from(&tdq->tdq_timeshare, tdq->tdq_ridx);
+	if (td != NULL) {
+		KASSERT(td->td_priority >= PRI_MIN_BATCH,
+		    ("tdq_choose: Invalid priority on timeshare queue %d",
+		    td->td_priority));
+		return (td);
+	}
+	td = runq_choose(&tdq->tdq_idle);
+	if (td != NULL) {
+		KASSERT(td->td_priority >= PRI_MIN_IDLE,
+		    ("tdq_choose: Invalid priority on idle queue %d",
+		    td->td_priority));
+		return (td);
+	}
+
+	return (NULL);
+}
+
+/*
+ * Initialize a thread queue.
+ */
+static void
+tdq_setup(struct tdq *tdq, int id)
+{
+
+	if (bootverbose)
+		printf("ULE: setup cpu %d\n", id);
+	runq_init(&tdq->tdq_realtime);
+	runq_init(&tdq->tdq_timeshare);
+	runq_init(&tdq->tdq_idle);
+	tdq->tdq_id = id;
+	snprintf(tdq->tdq_name, sizeof(tdq->tdq_name),
+	    "sched lock %d", (int)TDQ_ID(tdq));
+	mtx_init(&tdq->tdq_lock, tdq->tdq_name, "sched lock", MTX_SPIN);
+#ifdef KTR
+	snprintf(tdq->tdq_loadname, sizeof(tdq->tdq_loadname),
+	    "CPU %d load", (int)TDQ_ID(tdq));
+#endif
+}
+
+#ifdef SMP
+static void
+sched_setup_smp(void)
+{
+	struct tdq *tdq;
+	int i;
+
+	cpu_top = smp_topo();
+	CPU_FOREACH(i) {
+		tdq = DPCPU_ID_PTR(i, tdq);
+		tdq_setup(tdq, i);
+		tdq->tdq_cg = smp_topo_find(cpu_top, i);
+		if (tdq->tdq_cg == NULL)
+			panic("Can't find cpu group for %d\n", i);
+		DPCPU_ID_SET(i, randomval, i * 69069 + 5);
+	}
+	PCPU_SET(sched, DPCPU_PTR(tdq));
+	balance_tdq = TDQ_SELF();
+}
+#endif
+
+/*
+ * Setup the thread queues and initialize the topology based on MD
+ * information.
+ */
+static void
+sched_setup(void *dummy)
+{
+	struct tdq *tdq;
+
+#ifdef SMP
+	sched_setup_smp();
+#else
+	tdq_setup(TDQ_SELF(), 0);
+#endif
+	tdq = TDQ_SELF();
+
+	/* Add thread0's load since it's running. */
+	TDQ_LOCK(tdq);
+	thread0.td_lock = TDQ_LOCKPTR(tdq);
+	tdq_load_add(tdq, &thread0);
+	tdq->tdq_curthread = &thread0;
+	tdq->tdq_lowpri = thread0.td_priority;
+	TDQ_UNLOCK(tdq);
+}
+
+/*
+ * This routine determines time constants after stathz and hz are setup.
+ */
+/* ARGSUSED */
+static void
+sched_initticks(void *dummy)
+{
+	int incr;
+
+	realstathz = stathz ? stathz : hz;
+	sched_slice = realstathz / SCHED_SLICE_DEFAULT_DIVISOR;
+	sched_slice_min = sched_slice / SCHED_SLICE_MIN_DIVISOR;
+	hogticks = imax(1, (2 * hz * sched_slice + realstathz / 2) /
+	    realstathz);
+
+	/*
+	 * tickincr is shifted out by 10 to avoid rounding errors due to
+	 * hz not being evenly divisible by stathz on all platforms.
+	 */
+	incr = (hz << SCHED_TICK_SHIFT) / realstathz;
+	/*
+	 * This does not work for values of stathz that are more than
+	 * 1 << SCHED_TICK_SHIFT * hz.  In practice this does not happen.
+	 */
+	if (incr == 0)
+		incr = 1;
+	tickincr = incr;
+#ifdef SMP
+	/*
+	 * Set the default balance interval now that we know
+	 * what realstathz is.
+	 */
+	balance_interval = realstathz;
+	balance_ticks = balance_interval;
+	affinity = SCHED_AFFINITY_DEFAULT;
+#endif
+	if (sched_idlespinthresh < 0)
+		sched_idlespinthresh = 2 * max(10000, 6 * hz) / realstathz;
+}
+
+/*
+ * This is the core of the interactivity algorithm.  Determines a score based
+ * on past behavior.  It is the ratio of sleep time to run time scaled to
+ * a [0, 100] integer.  This is the voluntary sleep time of a process, which
+ * differs from the cpu usage because it does not account for time spent
+ * waiting on a run-queue.  Would be prettier if we had floating point.
+ *
+ * When a thread's sleep time is greater than its run time the
+ * calculation is:
+ *
+ *                           scaling factor 
+ * interactivity score =  ---------------------
+ *                        sleep time / run time
+ *
+ *
+ * When a thread's run time is greater than its sleep time the
+ * calculation is:
+ *
+ *                           scaling factor 
+ * interactivity score =  ---------------------    + scaling factor
+ *                        run time / sleep time
+ */
+static int
+sched_interact_score(struct thread *td)
+{
+	struct td_sched *ts;
+	int div;
+
+	ts = td_get_sched(td);
+	/*
+	 * The score is only needed if this is likely to be an interactive
+	 * task.  Don't go through the expense of computing it if there's
+	 * no chance.
+	 */
+	if (sched_interact <= SCHED_INTERACT_HALF &&
+		ts->ts_runtime >= ts->ts_slptime)
+			return (SCHED_INTERACT_HALF);
+
+	if (ts->ts_runtime > ts->ts_slptime) {
+		div = max(1, ts->ts_runtime / SCHED_INTERACT_HALF);
+		return (SCHED_INTERACT_HALF +
+		    (SCHED_INTERACT_HALF - (ts->ts_slptime / div)));
+	}
+	if (ts->ts_slptime > ts->ts_runtime) {
+		div = max(1, ts->ts_slptime / SCHED_INTERACT_HALF);
+		return (ts->ts_runtime / div);
+	}
+	/* runtime == slptime */
+	if (ts->ts_runtime)
+		return (SCHED_INTERACT_HALF);
+
+	/*
+	 * This can happen if slptime and runtime are 0.
+	 */
+	return (0);
+
+}
+
+/*
+ * Scale the scheduling priority according to the "interactivity" of this
+ * process.
+ */
+static void
+sched_priority(struct thread *td)
+{
+	u_int pri, score;
+
+	if (PRI_BASE(td->td_pri_class) != PRI_TIMESHARE)
+		return;
+	/*
+	 * If the score is interactive we place the thread in the realtime
+	 * queue with a priority that is less than kernel and interrupt
+	 * priorities.  These threads are not subject to nice restrictions.
+	 *
+	 * Scores greater than this are placed on the normal timeshare queue
+	 * where the priority is partially decided by the most recent cpu
+	 * utilization and the rest is decided by nice value.
+	 *
+	 * The nice value of the process has a linear effect on the calculated
+	 * score.  Negative nice values make it easier for a thread to be
+	 * considered interactive.
+	 */
+	score = imax(0, sched_interact_score(td) + td->td_proc->p_nice);
+	if (score < sched_interact) {
+		pri = PRI_MIN_INTERACT;
+		pri += (PRI_MAX_INTERACT - PRI_MIN_INTERACT + 1) * score /
+		    sched_interact;
+		KASSERT(pri >= PRI_MIN_INTERACT && pri <= PRI_MAX_INTERACT,
+		    ("sched_priority: invalid interactive priority %u score %u",
+		    pri, score));
+	} else {
+		pri = SCHED_PRI_MIN;
+		if (td_get_sched(td)->ts_ticks)
+			pri += min(SCHED_PRI_TICKS(td_get_sched(td)),
+			    SCHED_PRI_RANGE - 1);
+		pri += SCHED_PRI_NICE(td->td_proc->p_nice);
+		KASSERT(pri >= PRI_MIN_BATCH && pri <= PRI_MAX_BATCH,
+		    ("sched_priority: invalid priority %u: nice %d, "
+		    "ticks %d ftick %d ltick %d tick pri %d",
+		    pri, td->td_proc->p_nice, td_get_sched(td)->ts_ticks,
+		    td_get_sched(td)->ts_ftick, td_get_sched(td)->ts_ltick,
+		    SCHED_PRI_TICKS(td_get_sched(td))));
+	}
+	sched_user_prio(td, pri);
+
+	return;
+}
+
+/*
+ * This routine enforces a maximum limit on the amount of scheduling history
+ * kept.  It is called after either the slptime or runtime is adjusted.  This
+ * function is ugly due to integer math.
+ */
+static void
+sched_interact_update(struct thread *td)
+{
+	struct td_sched *ts;
+	u_int sum;
+
+	ts = td_get_sched(td);
+	sum = ts->ts_runtime + ts->ts_slptime;
+	if (sum < SCHED_SLP_RUN_MAX)
+		return;
+	/*
+	 * This only happens from two places:
+	 * 1) We have added an unusual amount of run time from fork_exit.
+	 * 2) We have added an unusual amount of sleep time from sched_sleep().
+	 */
+	if (sum > SCHED_SLP_RUN_MAX * 2) {
+		if (ts->ts_runtime > ts->ts_slptime) {
+			ts->ts_runtime = SCHED_SLP_RUN_MAX;
+			ts->ts_slptime = 1;
+		} else {
+			ts->ts_slptime = SCHED_SLP_RUN_MAX;
+			ts->ts_runtime = 1;
+		}
+		return;
+	}
+	/*
+	 * If we have exceeded by more than 1/5th then the algorithm below
+	 * will not bring us back into range.  Dividing by two here forces
+	 * us into the range of [4/5 * SCHED_INTERACT_MAX, SCHED_INTERACT_MAX]
+	 */
+	if (sum > (SCHED_SLP_RUN_MAX / 5) * 6) {
+		ts->ts_runtime /= 2;
+		ts->ts_slptime /= 2;
+		return;
+	}
+	ts->ts_runtime = (ts->ts_runtime / 5) * 4;
+	ts->ts_slptime = (ts->ts_slptime / 5) * 4;
+}
+
+/*
+ * Scale back the interactivity history when a child thread is created.  The
+ * history is inherited from the parent but the thread may behave totally
+ * differently.  For example, a shell spawning a compiler process.  We want
+ * to learn that the compiler is behaving badly very quickly.
+ */
+static void
+sched_interact_fork(struct thread *td)
+{
+	struct td_sched *ts;
+	int ratio;
+	int sum;
+
+	ts = td_get_sched(td);
+	sum = ts->ts_runtime + ts->ts_slptime;
+	if (sum > SCHED_SLP_RUN_FORK) {
+		ratio = sum / SCHED_SLP_RUN_FORK;
+		ts->ts_runtime /= ratio;
+		ts->ts_slptime /= ratio;
+	}
+}
+
+/*
+ * Called from proc0_init() to setup the scheduler fields.
+ */
+void
+schedinit(void)
+{
+	struct td_sched *ts0;
+
+	/*
+	 * Set up the scheduler specific parts of thread0.
+	 */
+	ts0 = td_get_sched(&thread0);
+	ts0->ts_ltick = ticks;
+	ts0->ts_ftick = ticks;
+	ts0->ts_slice = 0;
+	ts0->ts_cpu = curcpu;	/* set valid CPU number */
+}
+
+/*
+ * schedinit_ap() is needed prior to calling sched_throw(NULL) to ensure that
+ * the pcpu requirements are met for any calls in the period between curthread
+ * initialization and sched_throw().  One can safely add threads to the queue
+ * before sched_throw(), for instance, as long as the thread lock is setup
+ * correctly.
+ *
+ * TDQ_SELF() relies on the below sched pcpu setting; it may be used only
+ * after schedinit_ap().
+ */
+void
+schedinit_ap(void)
+{
+
+#ifdef SMP
+	PCPU_SET(sched, DPCPU_PTR(tdq));
+#endif
+	PCPU_GET(idlethread)->td_lock = TDQ_LOCKPTR(TDQ_SELF());
+}
+
+/*
+ * This is only somewhat accurate since given many processes of the same
+ * priority they will switch when their slices run out, which will be
+ * at most sched_slice stathz ticks.
+ */
+int
+sched_rr_interval(void)
+{
+
+	/* Convert sched_slice from stathz to hz. */
+	return (imax(1, (sched_slice * hz + realstathz / 2) / realstathz));
+}
+
+/*
+ * Update the percent cpu tracking information when it is requested or
+ * the total history exceeds the maximum.  We keep a sliding history of
+ * tick counts that slowly decays.  This is less precise than the 4BSD
+ * mechanism since it happens with less regular and frequent events.
+ */
+static void
+sched_pctcpu_update(struct td_sched *ts, int run)
+{
+	int t = ticks;
+
+	/*
+	 * The signed difference may be negative if the thread hasn't run for
+	 * over half of the ticks rollover period.
+	 */
+	if ((u_int)(t - ts->ts_ltick) >= SCHED_TICK_TARG) {
+		ts->ts_ticks = 0;
+		ts->ts_ftick = t - SCHED_TICK_TARG;
+	} else if (t - ts->ts_ftick >= SCHED_TICK_MAX) {
+		ts->ts_ticks = (ts->ts_ticks / (ts->ts_ltick - ts->ts_ftick)) *
+		    (ts->ts_ltick - (t - SCHED_TICK_TARG));
+		ts->ts_ftick = t - SCHED_TICK_TARG;
+	}
+	if (run)
+		ts->ts_ticks += (t - ts->ts_ltick) << SCHED_TICK_SHIFT;
+	ts->ts_ltick = t;
+}
+
+/*
+ * Adjust the priority of a thread.  Move it to the appropriate run-queue
+ * if necessary.  This is the back-end for several priority related
+ * functions.
+ */
+static void
+sched_thread_priority(struct thread *td, u_char prio)
+{
+	struct td_sched *ts;
+	struct tdq *tdq;
+	int oldpri;
+
+	KTR_POINT3(KTR_SCHED, "thread", sched_tdname(td), "prio",
+	    "prio:%d", td->td_priority, "new prio:%d", prio,
+	    KTR_ATTR_LINKED, sched_tdname(curthread));
+	SDT_PROBE3(sched, , , change__pri, td, td->td_proc, prio);
+	if (td != curthread && prio < td->td_priority) {
+		KTR_POINT3(KTR_SCHED, "thread", sched_tdname(curthread),
+		    "lend prio", "prio:%d", td->td_priority, "new prio:%d",
+		    prio, KTR_ATTR_LINKED, sched_tdname(td));
+		SDT_PROBE4(sched, , , lend__pri, td, td->td_proc, prio, 
+		    curthread);
+	} 
+	ts = td_get_sched(td);
+	THREAD_LOCK_ASSERT(td, MA_OWNED);
+	if (td->td_priority == prio)
+		return;
+	/*
+	 * If the priority has been elevated due to priority
+	 * propagation, we may have to move ourselves to a new
+	 * queue.  This could be optimized to not re-add in some
+	 * cases.
+	 */
+	if (TD_ON_RUNQ(td) && prio < td->td_priority) {
+		sched_rem(td);
+		td->td_priority = prio;
+		sched_add(td, SRQ_BORROWING | SRQ_HOLDTD);
+		return;
+	}
+	/*
+	 * If the thread is currently running we may have to adjust the lowpri
+	 * information so other cpus are aware of our current priority.
+	 */
+	if (TD_IS_RUNNING(td)) {
+		tdq = TDQ_CPU(ts->ts_cpu);
+		oldpri = td->td_priority;
+		td->td_priority = prio;
+		if (prio < tdq->tdq_lowpri)
+			tdq->tdq_lowpri = prio;
+		else if (tdq->tdq_lowpri == oldpri)
+			tdq_setlowpri(tdq, td);
+		return;
+	}
+	td->td_priority = prio;
+}
+
+/*
+ * Update a thread's priority when it is lent another thread's
+ * priority.
+ */
+void
+sched_lend_prio(struct thread *td, u_char prio)
+{
+
+	td->td_flags |= TDF_BORROWING;
+	sched_thread_priority(td, prio);
+}
+
+/*
+ * Restore a thread's priority when priority propagation is
+ * over.  The prio argument is the minimum priority the thread
+ * needs to have to satisfy other possible priority lending
+ * requests.  If the thread's regular priority is less
+ * important than prio, the thread will keep a priority boost
+ * of prio.
+ */
+void
+sched_unlend_prio(struct thread *td, u_char prio)
+{
+	u_char base_pri;
+
+	if (td->td_base_pri >= PRI_MIN_TIMESHARE &&
+	    td->td_base_pri <= PRI_MAX_TIMESHARE)
+		base_pri = td->td_user_pri;
+	else
+		base_pri = td->td_base_pri;
+	if (prio >= base_pri) {
+		td->td_flags &= ~TDF_BORROWING;
+		sched_thread_priority(td, base_pri);
+	} else
+		sched_lend_prio(td, prio);
+}
+
+/*
+ * Standard entry for setting the priority to an absolute value.
+ */
+void
+sched_prio(struct thread *td, u_char prio)
+{
+	u_char oldprio;
+
+	/* First, update the base priority. */
+	td->td_base_pri = prio;
+
+	/*
+	 * If the thread is borrowing another thread's priority, don't
+	 * ever lower the priority.
+	 */
+	if (td->td_flags & TDF_BORROWING && td->td_priority < prio)
+		return;
+
+	/* Change the real priority. */
+	oldprio = td->td_priority;
+	sched_thread_priority(td, prio);
+
+	/*
+	 * If the thread is on a turnstile, then let the turnstile update
+	 * its state.
+	 */
+	if (TD_ON_LOCK(td) && oldprio != prio)
+		turnstile_adjust(td, oldprio);
+}
+
+/*
+ * Set the base user priority, does not effect current running priority.
+ */
+void
+sched_user_prio(struct thread *td, u_char prio)
+{
+
+	td->td_base_user_pri = prio;
+	if (td->td_lend_user_pri <= prio)
+		return;
+	td->td_user_pri = prio;
+}
+
+void
+sched_lend_user_prio(struct thread *td, u_char prio)
+{
+
+	THREAD_LOCK_ASSERT(td, MA_OWNED);
+	td->td_lend_user_pri = prio;
+	td->td_user_pri = min(prio, td->td_base_user_pri);
+	if (td->td_priority > td->td_user_pri)
+		sched_prio(td, td->td_user_pri);
+	else if (td->td_priority != td->td_user_pri)
+		td->td_flags |= TDF_NEEDRESCHED;
+}
+
+/*
+ * Like the above but first check if there is anything to do.
+ */
+void
+sched_lend_user_prio_cond(struct thread *td, u_char prio)
+{
+
+	if (td->td_lend_user_pri == prio)
+		return;
+
+	thread_lock(td);
+	sched_lend_user_prio(td, prio);
+	thread_unlock(td);
+}
+
+#ifdef SMP
+/*
+ * This tdq is about to idle.  Try to steal a thread from another CPU before
+ * choosing the idle thread.
+ */
+static void
+tdq_trysteal(struct tdq *tdq)
+{
+	struct cpu_group *cg, *parent;
+	struct tdq *steal;
+	cpuset_t mask;
+	int cpu, i, goup;
+
+	if (smp_started == 0 || steal_idle == 0 || trysteal_limit == 0 ||
+	    tdq->tdq_cg == NULL)
+		return;
+	CPU_FILL(&mask);
+	CPU_CLR(PCPU_GET(cpuid), &mask);
+	/* We don't want to be preempted while we're iterating. */
+	spinlock_enter();
+	TDQ_UNLOCK(tdq);
+	for (i = 1, cg = tdq->tdq_cg, goup = 0; ; ) {
+		cpu = sched_highest(cg, &mask, steal_thresh, 1);
+		/*
+		 * If a thread was added while interrupts were disabled don't
+		 * steal one here.
+		 */
+		if (TDQ_LOAD(tdq) > 0) {
+			TDQ_LOCK(tdq);
+			break;
+		}
+
+		/*
+		 * We found no CPU to steal from in this group.  Escalate to
+		 * the parent and repeat.  But if parent has only two children
+		 * groups we can avoid searching this group again by searching
+		 * the other one specifically and then escalating two levels.
+		 */
+		if (cpu == -1) {
+			if (goup) {
+				cg = cg->cg_parent;
+				goup = 0;
+			}
+			if (++i > trysteal_limit) {
+				TDQ_LOCK(tdq);
+				break;
+			}
+			parent = cg->cg_parent;
+			if (parent == NULL) {
+				TDQ_LOCK(tdq);
+				break;
+			}
+			if (parent->cg_children == 2) {
+				if (cg == &parent->cg_child[0])
+					cg = &parent->cg_child[1];
+				else
+					cg = &parent->cg_child[0];
+				goup = 1;
+			} else
+				cg = parent;
+			continue;
+		}
+		steal = TDQ_CPU(cpu);
+		/*
+		 * The data returned by sched_highest() is stale and
+		 * the chosen CPU no longer has an eligible thread.
+		 * At this point unconditionally exit the loop to bound
+		 * the time spent in the critcal section.
+		 */
+		if (TDQ_LOAD(steal) < steal_thresh ||
+		    TDQ_TRANSFERABLE(steal) == 0)
+			continue;
+		/*
+		 * Try to lock both queues. If we are assigned a thread while
+		 * waited for the lock, switch to it now instead of stealing.
+		 * If we can't get the lock, then somebody likely got there
+		 * first.
+		 */
+		TDQ_LOCK(tdq);
+		if (tdq->tdq_load > 0)
+			break;
+		if (TDQ_TRYLOCK_FLAGS(steal, MTX_DUPOK) == 0)
+			break;
+		/*
+		 * The data returned by sched_highest() is stale and
+                 * the chosen CPU no longer has an eligible thread.
+		 */
+		if (TDQ_LOAD(steal) < steal_thresh ||
+		    TDQ_TRANSFERABLE(steal) == 0) {
+			TDQ_UNLOCK(steal);
+			break;
+		}
+		/*
+		 * If we fail to acquire one due to affinity restrictions,
+		 * bail out and let the idle thread to a more complete search
+		 * outside of a critical section.
+		 */
+		if (tdq_move(steal, tdq) == -1) {
+			TDQ_UNLOCK(steal);
+			break;
+		}
+		TDQ_UNLOCK(steal);
+		break;
+	}
+	spinlock_exit();
+}
+#endif
+
+/*
+ * Handle migration from sched_switch().  This happens only for
+ * cpu binding.
+ */
+static struct mtx *
+sched_switch_migrate(struct tdq *tdq, struct thread *td, int flags)
+{
+	struct tdq *tdn;
+#ifdef SMP
+	int lowpri;
+#endif
+
+	KASSERT(THREAD_CAN_MIGRATE(td) ||
+	    (td_get_sched(td)->ts_flags & TSF_BOUND) != 0,
+	    ("Thread %p shouldn't migrate", td));
+	KASSERT(!CPU_ABSENT(td_get_sched(td)->ts_cpu), ("sched_switch_migrate: "
+	    "thread %s queued on absent CPU %d.", td->td_name,
+	    td_get_sched(td)->ts_cpu));
+	tdn = TDQ_CPU(td_get_sched(td)->ts_cpu);
+#ifdef SMP
+	tdq_load_rem(tdq, td);
+	/*
+	 * Do the lock dance required to avoid LOR.  We have an 
+	 * extra spinlock nesting from sched_switch() which will
+	 * prevent preemption while we're holding neither run-queue lock.
+	 */
+	TDQ_UNLOCK(tdq);
+	TDQ_LOCK(tdn);
+	lowpri = tdq_add(tdn, td, flags);
+	tdq_notify(tdn, lowpri);
+	TDQ_UNLOCK(tdn);
+	TDQ_LOCK(tdq);
+#endif
+	return (TDQ_LOCKPTR(tdn));
+}
+
+/*
+ * thread_lock_unblock() that does not assume td_lock is blocked.
+ */
+static inline void
+thread_unblock_switch(struct thread *td, struct mtx *mtx)
+{
+	atomic_store_rel_ptr((volatile uintptr_t *)&td->td_lock,
+	    (uintptr_t)mtx);
+}
+
+/*
+ * Switch threads.  This function has to handle threads coming in while
+ * blocked for some reason, running, or idle.  It also must deal with
+ * migrating a thread from one queue to another as running threads may
+ * be assigned elsewhere via binding.
+ */
+void
+sched_switch(struct thread *td, int flags)
+{
+	struct thread *newtd;
+	struct tdq *tdq;
+	struct td_sched *ts;
+	struct mtx *mtx;
+	int srqflag;
+	int cpuid, preempted;
+#ifdef SMP
+	int pickcpu;
+#endif
+
+	THREAD_LOCK_ASSERT(td, MA_OWNED);
+
+	cpuid = PCPU_GET(cpuid);
+	tdq = TDQ_SELF();
+	ts = td_get_sched(td);
+	sched_pctcpu_update(ts, 1);
+#ifdef SMP
+	pickcpu = (td->td_flags & TDF_PICKCPU) != 0;
+	if (pickcpu)
+		ts->ts_rltick = ticks - affinity * MAX_CACHE_LEVELS;
+	else
+		ts->ts_rltick = ticks;
+#endif
+	td->td_lastcpu = td->td_oncpu;
+	preempted = (td->td_flags & TDF_SLICEEND) == 0 &&
+	    (flags & SW_PREEMPT) != 0;
+	td->td_flags &= ~(TDF_NEEDRESCHED | TDF_PICKCPU | TDF_SLICEEND);
+	td->td_owepreempt = 0;
+	atomic_store_char(&tdq->tdq_owepreempt, 0);
+	if (!TD_IS_IDLETHREAD(td))
+		TDQ_SWITCHCNT_INC(tdq);
+
+	/*
+	 * Always block the thread lock so we can drop the tdq lock early.
+	 */
+	mtx = thread_lock_block(td);
+	spinlock_enter();
+	if (TD_IS_IDLETHREAD(td)) {
+		MPASS(mtx == TDQ_LOCKPTR(tdq));
+		TD_SET_CAN_RUN(td);
+	} else if (TD_IS_RUNNING(td)) {
+		MPASS(mtx == TDQ_LOCKPTR(tdq));
+		srqflag = SRQ_OURSELF | SRQ_YIELDING |
+		    (preempted ? SRQ_PREEMPTED : 0);
+#ifdef SMP
+		if (THREAD_CAN_MIGRATE(td) && (!THREAD_CAN_SCHED(td, ts->ts_cpu)
+		    || pickcpu))
+			ts->ts_cpu = sched_pickcpu(td, 0);
+#endif
+		if (ts->ts_cpu == cpuid)
+			tdq_runq_add(tdq, td, srqflag);
+		else
+			mtx = sched_switch_migrate(tdq, td, srqflag);
+	} else {
+		/* This thread must be going to sleep. */
+		if (mtx != TDQ_LOCKPTR(tdq)) {
+			mtx_unlock_spin(mtx);
+			TDQ_LOCK(tdq);
+		}
+		tdq_load_rem(tdq, td);
+#ifdef SMP
+		if (tdq->tdq_load == 0)
+			tdq_trysteal(tdq);
+#endif
+	}
+
+#if (KTR_COMPILE & KTR_SCHED) != 0
+	if (TD_IS_IDLETHREAD(td))
+		KTR_STATE1(KTR_SCHED, "thread", sched_tdname(td), "idle",
+		    "prio:%d", td->td_priority);
+	else
+		KTR_STATE3(KTR_SCHED, "thread", sched_tdname(td), KTDSTATE(td),
+		    "prio:%d", td->td_priority, "wmesg:\"%s\"", td->td_wmesg,
+		    "lockname:\"%s\"", td->td_lockname);
+#endif
+
+	/*
+	 * We enter here with the thread blocked and assigned to the
+	 * appropriate cpu run-queue or sleep-queue and with the current
+	 * thread-queue locked.
+	 */
+	TDQ_LOCK_ASSERT(tdq, MA_OWNED | MA_NOTRECURSED);
+	MPASS(td == tdq->tdq_curthread);
+	newtd = choosethread();
+	sched_pctcpu_update(td_get_sched(newtd), 0);
+	TDQ_UNLOCK(tdq);
+
+	/*
+	 * Call the MD code to switch contexts if necessary.
+	 */
+	if (td != newtd) {
+#ifdef	HWPMC_HOOKS
+		if (PMC_PROC_IS_USING_PMCS(td->td_proc))
+			PMC_SWITCH_CONTEXT(td, PMC_FN_CSW_OUT);
+#endif
+		SDT_PROBE2(sched, , , off__cpu, newtd, newtd->td_proc);
+
+#ifdef KDTRACE_HOOKS
+		/*
+		 * If DTrace has set the active vtime enum to anything
+		 * other than INACTIVE (0), then it should have set the
+		 * function to call.
+		 */
+		if (dtrace_vtime_active)
+			(*dtrace_vtime_switch_func)(newtd);
+#endif
+		td->td_oncpu = NOCPU;
+		cpu_switch(td, newtd, mtx);
+		cpuid = td->td_oncpu = PCPU_GET(cpuid);
+
+		SDT_PROBE0(sched, , , on__cpu);
+#ifdef	HWPMC_HOOKS
+		if (PMC_PROC_IS_USING_PMCS(td->td_proc))
+			PMC_SWITCH_CONTEXT(td, PMC_FN_CSW_IN);
+#endif
+	} else {
+		thread_unblock_switch(td, mtx);
+		SDT_PROBE0(sched, , , remain__cpu);
+	}
+	KASSERT(curthread->td_md.md_spinlock_count == 1,
+	    ("invalid count %d", curthread->td_md.md_spinlock_count));
+
+	KTR_STATE1(KTR_SCHED, "thread", sched_tdname(td), "running",
+	    "prio:%d", td->td_priority);
+}
+
+/*
+ * Adjust thread priorities as a result of a nice request.
+ */
+void
+sched_nice(struct proc *p, int nice)
+{
+	struct thread *td;
+
+	PROC_LOCK_ASSERT(p, MA_OWNED);
+
+	p->p_nice = nice;
+	FOREACH_THREAD_IN_PROC(p, td) {
+		thread_lock(td);
+		sched_priority(td);
+		sched_prio(td, td->td_base_user_pri);
+		thread_unlock(td);
+	}
+}
+
+/*
+ * Record the sleep time for the interactivity scorer.
+ */
+void
+sched_sleep(struct thread *td, int prio)
+{
+
+	THREAD_LOCK_ASSERT(td, MA_OWNED);
+
+	td->td_slptick = ticks;
+	if (TD_IS_SUSPENDED(td) || prio >= PSOCK)
+		td->td_flags |= TDF_CANSWAP;
+	if (PRI_BASE(td->td_pri_class) != PRI_TIMESHARE)
+		return;
+	if (static_boost == 1 && prio)
+		sched_prio(td, prio);
+	else if (static_boost && td->td_priority > static_boost)
+		sched_prio(td, static_boost);
+}
+
+/*
+ * Schedule a thread to resume execution and record how long it voluntarily
+ * slept.  We also update the pctcpu, interactivity, and priority.
+ *
+ * Requires the thread lock on entry, drops on exit.
+ */
+void
+sched_wakeup(struct thread *td, int srqflags)
+{
+	struct td_sched *ts;
+	int slptick;
+
+	THREAD_LOCK_ASSERT(td, MA_OWNED);
+	ts = td_get_sched(td);
+	td->td_flags &= ~TDF_CANSWAP;
+
+	/*
+	 * If we slept for more than a tick update our interactivity and
+	 * priority.
+	 */
+	slptick = td->td_slptick;
+	td->td_slptick = 0;
+	if (slptick && slptick != ticks) {
+		ts->ts_slptime += (ticks - slptick) << SCHED_TICK_SHIFT;
+		sched_interact_update(td);
+		sched_pctcpu_update(ts, 0);
+	}
+	/*
+	 * Reset the slice value since we slept and advanced the round-robin.
+	 */
+	ts->ts_slice = 0;
+	sched_add(td, SRQ_BORING | srqflags);
+}
+
+/*
+ * Penalize the parent for creating a new child and initialize the child's
+ * priority.
+ */
+void
+sched_fork(struct thread *td, struct thread *child)
+{
+	THREAD_LOCK_ASSERT(td, MA_OWNED);
+	sched_pctcpu_update(td_get_sched(td), 1);
+	sched_fork_thread(td, child);
+	/*
+	 * Penalize the parent and child for forking.
+	 */
+	sched_interact_fork(child);
+	sched_priority(child);
+	td_get_sched(td)->ts_runtime += tickincr;
+	sched_interact_update(td);
+	sched_priority(td);
+}
+
+/*
+ * Fork a new thread, may be within the same process.
+ */
+void
+sched_fork_thread(struct thread *td, struct thread *child)
+{
+	struct td_sched *ts;
+	struct td_sched *ts2;
+	struct tdq *tdq;
+
+	tdq = TDQ_SELF();
+	THREAD_LOCK_ASSERT(td, MA_OWNED);
+	/*
+	 * Initialize child.
+	 */
+	ts = td_get_sched(td);
+	ts2 = td_get_sched(child);
+	child->td_oncpu = NOCPU;
+	child->td_lastcpu = NOCPU;
+	child->td_lock = TDQ_LOCKPTR(tdq);
+	child->td_cpuset = cpuset_ref(td->td_cpuset);
+	child->td_domain.dr_policy = td->td_cpuset->cs_domain;
+	ts2->ts_cpu = ts->ts_cpu;
+	ts2->ts_flags = 0;
+	/*
+	 * Grab our parents cpu estimation information.
+	 */
+	ts2->ts_ticks = ts->ts_ticks;
+	ts2->ts_ltick = ts->ts_ltick;
+	ts2->ts_ftick = ts->ts_ftick;
+	/*
+	 * Do not inherit any borrowed priority from the parent.
+	 */
+	child->td_priority = child->td_base_pri;
+	/*
+	 * And update interactivity score.
+	 */
+	ts2->ts_slptime = ts->ts_slptime;
+	ts2->ts_runtime = ts->ts_runtime;
+	/* Attempt to quickly learn interactivity. */
+	ts2->ts_slice = tdq_slice(tdq) - sched_slice_min;
+#ifdef KTR
+	bzero(ts2->ts_name, sizeof(ts2->ts_name));
+#endif
+}
+
+/*
+ * Adjust the priority class of a thread.
+ */
+void
+sched_class(struct thread *td, int class)
+{
+
+	THREAD_LOCK_ASSERT(td, MA_OWNED);
+	if (td->td_pri_class == class)
+		return;
+	td->td_pri_class = class;
+}
+
+/*
+ * Return some of the child's priority and interactivity to the parent.
+ */
+void
+sched_exit(struct proc *p, struct thread *child)
+{
+	struct thread *td;
+
+	KTR_STATE1(KTR_SCHED, "thread", sched_tdname(child), "proc exit",
+	    "prio:%d", child->td_priority);
+	PROC_LOCK_ASSERT(p, MA_OWNED);
+	td = FIRST_THREAD_IN_PROC(p);
+	sched_exit_thread(td, child);
+}
+
+/*
+ * Penalize another thread for the time spent on this one.  This helps to
+ * worsen the priority and interactivity of processes which schedule batch
+ * jobs such as make.  This has little effect on the make process itself but
+ * causes new processes spawned by it to receive worse scores immediately.
+ */
+void
+sched_exit_thread(struct thread *td, struct thread *child)
+{
+
+	KTR_STATE1(KTR_SCHED, "thread", sched_tdname(child), "thread exit",
+	    "prio:%d", child->td_priority);
+	/*
+	 * Give the child's runtime to the parent without returning the
+	 * sleep time as a penalty to the parent.  This causes shells that
+	 * launch expensive things to mark their children as expensive.
+	 */
+	thread_lock(td);
+	td_get_sched(td)->ts_runtime += td_get_sched(child)->ts_runtime;
+	sched_interact_update(td);
+	sched_priority(td);
+	thread_unlock(td);
+}
+
+void
+sched_preempt(struct thread *td)
+{
+	struct tdq *tdq;
+	int flags;
+
+	SDT_PROBE2(sched, , , surrender, td, td->td_proc);
+
+	thread_lock(td);
+	tdq = TDQ_SELF();
+	TDQ_LOCK_ASSERT(tdq, MA_OWNED);
+	if (td->td_priority > tdq->tdq_lowpri) {
+		if (td->td_critnest == 1) {
+			flags = SW_INVOL | SW_PREEMPT;
+			flags |= TD_IS_IDLETHREAD(td) ? SWT_REMOTEWAKEIDLE :
+			    SWT_REMOTEPREEMPT;
+			mi_switch(flags);
+			/* Switch dropped thread lock. */
+			return;
+		}
+		td->td_owepreempt = 1;
+	} else {
+		tdq->tdq_owepreempt = 0;
+	}
+	thread_unlock(td);
+}
+
+/*
+ * Fix priorities on return to user-space.  Priorities may be elevated due
+ * to static priorities in msleep() or similar.
+ */
+void
+sched_userret_slowpath(struct thread *td)
+{
+
+	thread_lock(td);
+	td->td_priority = td->td_user_pri;
+	td->td_base_pri = td->td_user_pri;
+	tdq_setlowpri(TDQ_SELF(), td);
+	thread_unlock(td);
+}
+
+/*
+ * Handle a stathz tick.  This is really only relevant for timeshare
+ * threads.
+ */
+void
+sched_clock(struct thread *td, int cnt)
+{
+	struct tdq *tdq;
+	struct td_sched *ts;
+
+	THREAD_LOCK_ASSERT(td, MA_OWNED);
+	tdq = TDQ_SELF();
+#ifdef SMP
+	/*
+	 * We run the long term load balancer infrequently on the first cpu.
+	 */
+	if (balance_tdq == tdq && smp_started != 0 && rebalance != 0 &&
+	    balance_ticks != 0) {
+		balance_ticks -= cnt;
+		if (balance_ticks <= 0)
+			sched_balance();
+	}
+#endif
+	/*
+	 * Save the old switch count so we have a record of the last ticks
+	 * activity.   Initialize the new switch count based on our load.
+	 * If there is some activity seed it to reflect that.
+	 */
+	tdq->tdq_oldswitchcnt = tdq->tdq_switchcnt;
+	tdq->tdq_switchcnt = tdq->tdq_load;
+
+	/*
+	 * Advance the insert index once for each tick to ensure that all
+	 * threads get a chance to run.
+	 */
+	if (tdq->tdq_idx == tdq->tdq_ridx) {
+		tdq->tdq_idx = (tdq->tdq_idx + 1) % RQ_NQS;
+		if (TAILQ_EMPTY(&tdq->tdq_timeshare.rq_queues[tdq->tdq_ridx]))
+			tdq->tdq_ridx = tdq->tdq_idx;
+	}
+	ts = td_get_sched(td);
+	sched_pctcpu_update(ts, 1);
+	if ((td->td_pri_class & PRI_FIFO_BIT) || TD_IS_IDLETHREAD(td))
+		return;
+
+	if (PRI_BASE(td->td_pri_class) == PRI_TIMESHARE) {
+		/*
+		 * We used a tick; charge it to the thread so
+		 * that we can compute our interactivity.
+		 */
+		td_get_sched(td)->ts_runtime += tickincr * cnt;
+		sched_interact_update(td);
+		sched_priority(td);
+	}
+
+	/*
+	 * Force a context switch if the current thread has used up a full
+	 * time slice (default is 100ms).
+	 */
+	ts->ts_slice += cnt;
+	if (ts->ts_slice >= tdq_slice(tdq)) {
+		ts->ts_slice = 0;
+		td->td_flags |= TDF_NEEDRESCHED | TDF_SLICEEND;
+	}
+}
+
+u_int
+sched_estcpu(struct thread *td __unused)
+{
+
+	return (0);
+}
+
+/*
+ * Return whether the current CPU has runnable tasks.  Used for in-kernel
+ * cooperative idle threads.
+ */
+int
+sched_runnable(void)
+{
+	struct tdq *tdq;
+	int load;
+
+	load = 1;
+
+	tdq = TDQ_SELF();
+	if ((curthread->td_flags & TDF_IDLETD) != 0) {
+		if (TDQ_LOAD(tdq) > 0)
+			goto out;
+	} else
+		if (TDQ_LOAD(tdq) - 1 > 0)
+			goto out;
+	load = 0;
+out:
+	return (load);
+}
+
+/*
+ * Choose the highest priority thread to run.  The thread is removed from
+ * the run-queue while running however the load remains.
+ */
+struct thread *
+sched_choose(void)
+{
+	struct thread *td;
+	struct tdq *tdq;
+
+	tdq = TDQ_SELF();
+	TDQ_LOCK_ASSERT(tdq, MA_OWNED);
+	td = tdq_choose(tdq);
+	if (td != NULL) {
+		tdq_runq_rem(tdq, td);
+		tdq->tdq_lowpri = td->td_priority;
+	} else { 
+		tdq->tdq_lowpri = PRI_MAX_IDLE;
+		td = PCPU_GET(idlethread);
+	}
+	tdq->tdq_curthread = td;
+	return (td);
+}
+
+/*
+ * Set owepreempt if the currently running thread has lower priority than "pri".
+ * Preemption never happens directly in ULE, we always request it once we exit a
+ * critical section.
+ */
+static void
+sched_setpreempt(int pri)
+{
+	struct thread *ctd;
+	int cpri;
+
+	ctd = curthread;
+	THREAD_LOCK_ASSERT(ctd, MA_OWNED);
+
+	cpri = ctd->td_priority;
+	if (pri < cpri)
+		ctd->td_flags |= TDF_NEEDRESCHED;
+	if (KERNEL_PANICKED() || pri >= cpri || cold || TD_IS_INHIBITED(ctd))
+		return;
+	if (!sched_shouldpreempt(pri, cpri, 0))
+		return;
+	ctd->td_owepreempt = 1;
+}
+
+/*
+ * Add a thread to a thread queue.  Select the appropriate runq and add the
+ * thread to it.  This is the internal function called when the tdq is
+ * predetermined.
+ */
+static int
+tdq_add(struct tdq *tdq, struct thread *td, int flags)
+{
+	int lowpri;
+
+	TDQ_LOCK_ASSERT(tdq, MA_OWNED);
+	THREAD_LOCK_BLOCKED_ASSERT(td, MA_OWNED);
+	KASSERT((td->td_inhibitors == 0),
+	    ("sched_add: trying to run inhibited thread"));
+	KASSERT((TD_CAN_RUN(td) || TD_IS_RUNNING(td)),
+	    ("sched_add: bad thread state"));
+	KASSERT(td->td_flags & TDF_INMEM,
+	    ("sched_add: thread swapped out"));
+
+	lowpri = tdq->tdq_lowpri;
+	if (td->td_priority < lowpri)
+		tdq->tdq_lowpri = td->td_priority;
+	tdq_runq_add(tdq, td, flags);
+	tdq_load_add(tdq, td);
+	return (lowpri);
+}
+
+/*
+ * Select the target thread queue and add a thread to it.  Request
+ * preemption or IPI a remote processor if required.
+ *
+ * Requires the thread lock on entry, drops on exit.
+ */
+void
+sched_add(struct thread *td, int flags)
+{
+	struct tdq *tdq;
+#ifdef SMP
+	int cpu, lowpri;
+#endif
+
+	KTR_STATE2(KTR_SCHED, "thread", sched_tdname(td), "runq add",
+	    "prio:%d", td->td_priority, KTR_ATTR_LINKED,
+	    sched_tdname(curthread));
+	KTR_POINT1(KTR_SCHED, "thread", sched_tdname(curthread), "wokeup",
+	    KTR_ATTR_LINKED, sched_tdname(td));
+	SDT_PROBE4(sched, , , enqueue, td, td->td_proc, NULL, 
+	    flags & SRQ_PREEMPTED);
+	THREAD_LOCK_ASSERT(td, MA_OWNED);
+	/*
+	 * Recalculate the priority before we select the target cpu or
+	 * run-queue.
+	 */
+	if (PRI_BASE(td->td_pri_class) == PRI_TIMESHARE)
+		sched_priority(td);
+#ifdef SMP
+	/*
+	 * Pick the destination cpu and if it isn't ours transfer to the
+	 * target cpu.
+	 */
+	cpu = sched_pickcpu(td, flags);
+	tdq = sched_setcpu(td, cpu, flags);
+	lowpri = tdq_add(tdq, td, flags);
+	if (cpu != PCPU_GET(cpuid))
+		tdq_notify(tdq, lowpri);
+	else if (!(flags & SRQ_YIELDING))
+		sched_setpreempt(td->td_priority);
+#else
+	tdq = TDQ_SELF();
+	/*
+	 * Now that the thread is moving to the run-queue, set the lock
+	 * to the scheduler's lock.
+	 */
+	if (td->td_lock != TDQ_LOCKPTR(tdq)) {
+		TDQ_LOCK(tdq);
+		if ((flags & SRQ_HOLD) != 0)
+			td->td_lock = TDQ_LOCKPTR(tdq);
+		else
+			thread_lock_set(td, TDQ_LOCKPTR(tdq));
+	}
+	(void)tdq_add(tdq, td, flags);
+	if (!(flags & SRQ_YIELDING))
+		sched_setpreempt(td->td_priority);
+#endif
+	if (!(flags & SRQ_HOLDTD))
+		thread_unlock(td);
+}
+
+/*
+ * Remove a thread from a run-queue without running it.  This is used
+ * when we're stealing a thread from a remote queue.  Otherwise all threads
+ * exit by calling sched_exit_thread() and sched_throw() themselves.
+ */
+void
+sched_rem(struct thread *td)
+{
+	struct tdq *tdq;
+
+	KTR_STATE1(KTR_SCHED, "thread", sched_tdname(td), "runq rem",
+	    "prio:%d", td->td_priority);
+	SDT_PROBE3(sched, , , dequeue, td, td->td_proc, NULL);
+	tdq = TDQ_CPU(td_get_sched(td)->ts_cpu);
+	TDQ_LOCK_ASSERT(tdq, MA_OWNED);
+	MPASS(td->td_lock == TDQ_LOCKPTR(tdq));
+	KASSERT(TD_ON_RUNQ(td),
+	    ("sched_rem: thread not on run queue"));
+	tdq_runq_rem(tdq, td);
+	tdq_load_rem(tdq, td);
+	TD_SET_CAN_RUN(td);
+	if (td->td_priority == tdq->tdq_lowpri)
+		tdq_setlowpri(tdq, NULL);
+}
+
+/*
+ * Fetch cpu utilization information.  Updates on demand.
+ */
+fixpt_t
+sched_pctcpu(struct thread *td)
+{
+	fixpt_t pctcpu;
+	struct td_sched *ts;
+
+	pctcpu = 0;
+	ts = td_get_sched(td);
+
+	THREAD_LOCK_ASSERT(td, MA_OWNED);
+	sched_pctcpu_update(ts, TD_IS_RUNNING(td));
+	if (ts->ts_ticks) {
+		int rtick;
+
+		/* How many rtick per second ? */
+		rtick = min(SCHED_TICK_HZ(ts) / SCHED_TICK_SECS, hz);
+		pctcpu = (FSCALE * ((FSCALE * rtick)/hz)) >> FSHIFT;
+	}
+
+	return (pctcpu);
+}
+
+/*
+ * Enforce affinity settings for a thread.  Called after adjustments to
+ * cpumask.
+ */
+void
+sched_affinity(struct thread *td)
+{
+#ifdef SMP
+	struct td_sched *ts;
+
+	THREAD_LOCK_ASSERT(td, MA_OWNED);
+	ts = td_get_sched(td);
+	if (THREAD_CAN_SCHED(td, ts->ts_cpu))
+		return;
+	if (TD_ON_RUNQ(td)) {
+		sched_rem(td);
+		sched_add(td, SRQ_BORING | SRQ_HOLDTD);
+		return;
+	}
+	if (!TD_IS_RUNNING(td))
+		return;
+	/*
+	 * Force a switch before returning to userspace.  If the
+	 * target thread is not running locally send an ipi to force
+	 * the issue.
+	 */
+	td->td_flags |= TDF_NEEDRESCHED;
+	if (td != curthread)
+		ipi_cpu(ts->ts_cpu, IPI_PREEMPT);
+#endif
+}
+
+/*
+ * Bind a thread to a target cpu.
+ */
+void
+sched_bind(struct thread *td, int cpu)
+{
+	struct td_sched *ts;
+
+	THREAD_LOCK_ASSERT(td, MA_OWNED|MA_NOTRECURSED);
+	KASSERT(td == curthread, ("sched_bind: can only bind curthread"));
+	ts = td_get_sched(td);
+	if (ts->ts_flags & TSF_BOUND)
+		sched_unbind(td);
+	KASSERT(THREAD_CAN_MIGRATE(td), ("%p must be migratable", td));
+	ts->ts_flags |= TSF_BOUND;
+	sched_pin();
+	if (PCPU_GET(cpuid) == cpu)
+		return;
+	ts->ts_cpu = cpu;
+	/* When we return from mi_switch we'll be on the correct cpu. */
+	mi_switch(SW_VOL);
+	thread_lock(td);
+}
+
+/*
+ * Release a bound thread.
+ */
+void
+sched_unbind(struct thread *td)
+{
+	struct td_sched *ts;
+
+	THREAD_LOCK_ASSERT(td, MA_OWNED);
+	KASSERT(td == curthread, ("sched_unbind: can only bind curthread"));
+	ts = td_get_sched(td);
+	if ((ts->ts_flags & TSF_BOUND) == 0)
+		return;
+	ts->ts_flags &= ~TSF_BOUND;
+	sched_unpin();
+}
+
+int
+sched_is_bound(struct thread *td)
+{
+	THREAD_LOCK_ASSERT(td, MA_OWNED);
+	return (td_get_sched(td)->ts_flags & TSF_BOUND);
+}
+
+/*
+ * Basic yield call.
+ */
+void
+sched_relinquish(struct thread *td)
+{
+	thread_lock(td);
+	mi_switch(SW_VOL | SWT_RELINQUISH);
+}
+
+/*
+ * Return the total system load.
+ */
+int
+sched_load(void)
+{
+#ifdef SMP
+	int total;
+	int i;
+
+	total = 0;
+	CPU_FOREACH(i)
+		total += atomic_load_int(&TDQ_CPU(i)->tdq_sysload);
+	return (total);
+#else
+	return (atomic_load_int(&TDQ_SELF()->tdq_sysload));
+#endif
+}
+
+int
+sched_sizeof_proc(void)
+{
+	return (sizeof(struct proc));
+}
+
+int
+sched_sizeof_thread(void)
+{
+	return (sizeof(struct thread) + sizeof(struct td_sched));
+}
+
+#ifdef SMP
+#define	TDQ_IDLESPIN(tdq)						\
+    ((tdq)->tdq_cg != NULL && ((tdq)->tdq_cg->cg_flags & CG_FLAG_THREAD) == 0)
+#else
+#define	TDQ_IDLESPIN(tdq)	1
+#endif
+
+/*
+ * The actual idle process.
+ */
+void
+sched_idletd(void *dummy)
+{
+	struct thread *td;
+	struct tdq *tdq;
+	int oldswitchcnt, switchcnt;
+	int i;
+
+	mtx_assert(&Giant, MA_NOTOWNED);
+	td = curthread;
+	tdq = TDQ_SELF();
+	THREAD_NO_SLEEPING();
+	oldswitchcnt = -1;
+	for (;;) {
+		if (TDQ_LOAD(tdq)) {
+			thread_lock(td);
+			mi_switch(SW_VOL | SWT_IDLE);
+		}
+		switchcnt = TDQ_SWITCHCNT(tdq);
+#ifdef SMP
+		if (always_steal || switchcnt != oldswitchcnt) {
+			oldswitchcnt = switchcnt;
+			if (tdq_idled(tdq) == 0)
+				continue;
+		}
+		switchcnt = TDQ_SWITCHCNT(tdq);
+#else
+		oldswitchcnt = switchcnt;
+#endif
+		/*
+		 * If we're switching very frequently, spin while checking
+		 * for load rather than entering a low power state that 
+		 * may require an IPI.  However, don't do any busy
+		 * loops while on SMT machines as this simply steals
+		 * cycles from cores doing useful work.
+		 */
+		if (TDQ_IDLESPIN(tdq) && switchcnt > sched_idlespinthresh) {
+			for (i = 0; i < sched_idlespins; i++) {
+				if (TDQ_LOAD(tdq))
+					break;
+				cpu_spinwait();
+			}
+		}
+
+		/* If there was context switch during spin, restart it. */
+		switchcnt = TDQ_SWITCHCNT(tdq);
+		if (TDQ_LOAD(tdq) != 0 || switchcnt != oldswitchcnt)
+			continue;
+
+		/* Run main MD idle handler. */
+		atomic_store_int(&tdq->tdq_cpu_idle, 1);
+		/*
+		 * Make sure that the tdq_cpu_idle update is globally visible
+		 * before cpu_idle() reads tdq_load.  The order is important
+		 * to avoid races with tdq_notify().
+		 */
+		atomic_thread_fence_seq_cst();
+		/*
+		 * Checking for again after the fence picks up assigned
+		 * threads often enough to make it worthwhile to do so in
+		 * order to avoid calling cpu_idle().
+		 */
+		if (TDQ_LOAD(tdq) != 0) {
+			atomic_store_int(&tdq->tdq_cpu_idle, 0);
+			continue;
+		}
+		cpu_idle(switchcnt * 4 > sched_idlespinthresh);
+		atomic_store_int(&tdq->tdq_cpu_idle, 0);
+
+		/*
+		 * Account thread-less hardware interrupts and
+		 * other wakeup reasons equal to context switches.
+		 */
+		switchcnt = TDQ_SWITCHCNT(tdq);
+		if (switchcnt != oldswitchcnt)
+			continue;
+		TDQ_SWITCHCNT_INC(tdq);
+		oldswitchcnt++;
+	}
+}
+
+/*
+ * A CPU is entering for the first time or a thread is exiting.
+ */
+void
+sched_throw(struct thread *td)
+{
+	struct thread *newtd;
+	struct tdq *tdq;
+
+	tdq = TDQ_SELF();
+	if (__predict_false(td == NULL)) {
+		TDQ_LOCK(tdq);
+		/* Correct spinlock nesting. */
+		spinlock_exit();
+		PCPU_SET(switchtime, cpu_ticks());
+		PCPU_SET(switchticks, ticks);
+	} else {
+		THREAD_LOCK_ASSERT(td, MA_OWNED);
+		THREAD_LOCKPTR_ASSERT(td, TDQ_LOCKPTR(tdq));
+		tdq_load_rem(tdq, td);
+		td->td_lastcpu = td->td_oncpu;
+		td->td_oncpu = NOCPU;
+		thread_lock_block(td);
+	}
+	newtd = choosethread();
+	spinlock_enter();
+	TDQ_UNLOCK(tdq);
+	KASSERT(curthread->td_md.md_spinlock_count == 1,
+	    ("invalid count %d", curthread->td_md.md_spinlock_count));
+	/* doesn't return */
+	if (__predict_false(td == NULL))
+		cpu_throw(td, newtd);		/* doesn't return */
+	else
+		cpu_switch(td, newtd, TDQ_LOCKPTR(tdq));
+}
+
+/*
+ * This is called from fork_exit().  Just acquire the correct locks and
+ * let fork do the rest of the work.
+ */
+void
+sched_fork_exit(struct thread *td)
+{
+	struct tdq *tdq;
+	int cpuid;
+
+	/*
+	 * Finish setting up thread glue so that it begins execution in a
+	 * non-nested critical section with the scheduler lock held.
+	 */
+	KASSERT(curthread->td_md.md_spinlock_count == 1,
+	    ("invalid count %d", curthread->td_md.md_spinlock_count));
+	cpuid = PCPU_GET(cpuid);
+	tdq = TDQ_SELF();
+	TDQ_LOCK(tdq);
+	spinlock_exit();
+	MPASS(td->td_lock == TDQ_LOCKPTR(tdq));
+	td->td_oncpu = cpuid;
+	KTR_STATE1(KTR_SCHED, "thread", sched_tdname(td), "running",
+	    "prio:%d", td->td_priority);
+	SDT_PROBE0(sched, , , on__cpu);
+}
+
+/*
+ * Create on first use to catch odd startup conditions.
+ */
+char *
+sched_tdname(struct thread *td)
+{
+#ifdef KTR
+	struct td_sched *ts;
+
+	ts = td_get_sched(td);
+	if (ts->ts_name[0] == '\0')
+		snprintf(ts->ts_name, sizeof(ts->ts_name),
+		    "%s tid %d", td->td_name, td->td_tid);
+	return (ts->ts_name);
+#else
+	return (td->td_name);
+#endif
+}
+
+#ifdef KTR
+void
+sched_clear_tdname(struct thread *td)
+{
+	struct td_sched *ts;
+
+	ts = td_get_sched(td);
+	ts->ts_name[0] = '\0';
+}
+#endif
+
+#ifdef SMP
+
+/*
+ * Build the CPU topology dump string. Is recursively called to collect
+ * the topology tree.
+ */
+static int
+sysctl_kern_sched_topology_spec_internal(struct sbuf *sb, struct cpu_group *cg,
+    int indent)
+{
+	char cpusetbuf[CPUSETBUFSIZ];
+	int i, first;
+
+	sbuf_printf(sb, "%*s<group level=\"%d\" cache-level=\"%d\">\n", indent,
+	    "", 1 + indent / 2, cg->cg_level);
+	sbuf_printf(sb, "%*s <cpu count=\"%d\" mask=\"%s\">", indent, "",
+	    cg->cg_count, cpusetobj_strprint(cpusetbuf, &cg->cg_mask));
+	first = TRUE;
+	for (i = cg->cg_first; i <= cg->cg_last; i++) {
+		if (CPU_ISSET(i, &cg->cg_mask)) {
+			if (!first)
+				sbuf_printf(sb, ", ");
+			else
+				first = FALSE;
+			sbuf_printf(sb, "%d", i);
+		}
+	}
+	sbuf_printf(sb, "</cpu>\n");
+
+	if (cg->cg_flags != 0) {
+		sbuf_printf(sb, "%*s <flags>", indent, "");
+		if ((cg->cg_flags & CG_FLAG_HTT) != 0)
+			sbuf_printf(sb, "<flag name=\"HTT\">HTT group</flag>");
+		if ((cg->cg_flags & CG_FLAG_THREAD) != 0)
+			sbuf_printf(sb, "<flag name=\"THREAD\">THREAD group</flag>");
+		if ((cg->cg_flags & CG_FLAG_SMT) != 0)
+			sbuf_printf(sb, "<flag name=\"SMT\">SMT group</flag>");
+		if ((cg->cg_flags & CG_FLAG_NODE) != 0)
+			sbuf_printf(sb, "<flag name=\"NODE\">NUMA node</flag>");
+		sbuf_printf(sb, "</flags>\n");
+	}
+
+	if (cg->cg_children > 0) {
+		sbuf_printf(sb, "%*s <children>\n", indent, "");
+		for (i = 0; i < cg->cg_children; i++)
+			sysctl_kern_sched_topology_spec_internal(sb, 
+			    &cg->cg_child[i], indent+2);
+		sbuf_printf(sb, "%*s </children>\n", indent, "");
+	}
+	sbuf_printf(sb, "%*s</group>\n", indent, "");
+	return (0);
+}
+
+/*
+ * Sysctl handler for retrieving topology dump. It's a wrapper for
+ * the recursive sysctl_kern_smp_topology_spec_internal().
+ */
+static int
+sysctl_kern_sched_topology_spec(SYSCTL_HANDLER_ARGS)
+{
+	struct sbuf *topo;
+	int err;
+
+	KASSERT(cpu_top != NULL, ("cpu_top isn't initialized"));
+
+	topo = sbuf_new_for_sysctl(NULL, NULL, 512, req);
+	if (topo == NULL)
+		return (ENOMEM);
+
+	sbuf_printf(topo, "<groups>\n");
+	err = sysctl_kern_sched_topology_spec_internal(topo, cpu_top, 1);
+	sbuf_printf(topo, "</groups>\n");
+
+	if (err == 0) {
+		err = sbuf_finish(topo);
+	}
+	sbuf_delete(topo);
+	return (err);
+}
+
+/*
+ * Debug dump of the per-CPU hybrid core classification, one "cpuid:class"
+ * pair per present CPU.  Class 1 = performance, 2 = efficiency, 4 = LP-E.
+ */
+static int
+sysctl_kern_sched_core_class(SYSCTL_HANDLER_ARGS)
+{
+	struct sbuf *sb;
+	int err, i;
+
+	sb = sbuf_new_for_sysctl(NULL, NULL, 128, req);
+	if (sb == NULL)
+		return (ENOMEM);
+	CPU_FOREACH(i)
+		sbuf_printf(sb, "%s%d:%u", i == 0 ? "" : " ", i,
+		    cpu_core_class[i]);
+	err = sbuf_finish(sb);
+	sbuf_delete(sb);
+	return (err);
+}
+
+#endif
+
+static int
+sysctl_kern_quantum(SYSCTL_HANDLER_ARGS)
+{
+	int error, new_val, period;
+
+	period = 1000000 / realstathz;
+	new_val = period * sched_slice;
+	error = sysctl_handle_int(oidp, &new_val, 0, req);
+	if (error != 0 || req->newptr == NULL)
+		return (error);
+	if (new_val <= 0)
+		return (EINVAL);
+	sched_slice = imax(1, (new_val + period / 2) / period);
+	sched_slice_min = sched_slice / SCHED_SLICE_MIN_DIVISOR;
+	hogticks = imax(1, (2 * hz * sched_slice + realstathz / 2) /
+	    realstathz);
+	return (0);
+}
+
+SYSCTL_NODE(_kern, OID_AUTO, sched, CTLFLAG_RW | CTLFLAG_MPSAFE, 0,
+    "Scheduler");
+SYSCTL_STRING(_kern_sched, OID_AUTO, name, CTLFLAG_RD, "ULE", 0,
+    "Scheduler name");
+SYSCTL_PROC(_kern_sched, OID_AUTO, quantum,
+    CTLTYPE_INT | CTLFLAG_RW | CTLFLAG_MPSAFE, NULL, 0,
+    sysctl_kern_quantum, "I",
+    "Quantum for timeshare threads in microseconds");
+SYSCTL_INT(_kern_sched, OID_AUTO, slice, CTLFLAG_RW, &sched_slice, 0,
+    "Quantum for timeshare threads in stathz ticks");
+SYSCTL_UINT(_kern_sched, OID_AUTO, interact, CTLFLAG_RW, &sched_interact, 0,
+    "Interactivity score threshold");
+SYSCTL_INT(_kern_sched, OID_AUTO, preempt_thresh, CTLFLAG_RW,
+    &preempt_thresh, 0,
+    "Maximal (lowest) priority for preemption");
+SYSCTL_INT(_kern_sched, OID_AUTO, static_boost, CTLFLAG_RW, &static_boost, 0,
+    "Assign static kernel priorities to sleeping threads");
+SYSCTL_INT(_kern_sched, OID_AUTO, idlespins, CTLFLAG_RW, &sched_idlespins, 0,
+    "Number of times idle thread will spin waiting for new work");
+SYSCTL_INT(_kern_sched, OID_AUTO, idlespinthresh, CTLFLAG_RW,
+    &sched_idlespinthresh, 0,
+    "Threshold before we will permit idle thread spinning");
+#ifdef SMP
+SYSCTL_INT(_kern_sched, OID_AUTO, affinity, CTLFLAG_RW, &affinity, 0,
+    "Number of hz ticks to keep thread affinity for");
+SYSCTL_INT(_kern_sched, OID_AUTO, balance, CTLFLAG_RW, &rebalance, 0,
+    "Enables the long-term load balancer");
+SYSCTL_INT(_kern_sched, OID_AUTO, balance_interval, CTLFLAG_RW,
+    &balance_interval, 0,
+    "Average period in stathz ticks to run the long-term balancer");
+SYSCTL_INT(_kern_sched, OID_AUTO, steal_idle, CTLFLAG_RW, &steal_idle, 0,
+    "Attempts to steal work from other cores before idling");
+SYSCTL_INT(_kern_sched, OID_AUTO, steal_thresh, CTLFLAG_RW, &steal_thresh, 0,
+    "Minimum load on remote CPU before we'll steal");
+SYSCTL_INT(_kern_sched, OID_AUTO, trysteal_limit, CTLFLAG_RW, &trysteal_limit,
+    0, "Topological distance limit for stealing threads in sched_switch()");
+SYSCTL_INT(_kern_sched, OID_AUTO, always_steal, CTLFLAG_RW, &always_steal, 0,
+    "Always run the stealer from the idle thread");
+SYSCTL_PROC(_kern_sched, OID_AUTO, topology_spec, CTLTYPE_STRING |
+    CTLFLAG_MPSAFE | CTLFLAG_RD, NULL, 0, sysctl_kern_sched_topology_spec, "A",
+    "XML dump of detected CPU topology");
+SYSCTL_INT(_kern_sched, OID_AUTO, class_weight_eff, CTLFLAG_RW,
+    &sched_class_weight_eff, 0,
+    "Load penalty for class-2 cores (E-core / AMD compute CCD / C-core)");
+SYSCTL_INT(_kern_sched, OID_AUTO, class_weight_lp, CTLFLAG_RW,
+    &sched_class_weight_lp, 0,
+    "Load penalty for class-4 cores (Intel LP-E), scheduled last");
+SYSCTL_INT(_kern_sched, OID_AUTO, smt_busy_penalty, CTLFLAG_RW,
+    &sched_smt_busy_penalty, 0,
+    "Penalty for a free thread whose SMT sibling is busy (0 = ULE behavior)");
+SYSCTL_INT(_kern_sched, OID_AUTO, prefer_compute, CTLFLAG_RW,
+    &sched_prefer_compute, 0,
+    "AMD hybrid CCD: 0 = favor cache (V-Cache) die, 1 = favor compute die");
+SYSCTL_INT(_kern_sched, OID_AUTO, detect_lpe, CTLFLAG_RDTUN,
+    &sched_detect_lpe, 0,
+    "Detect Intel LP-E cores (no L3) as class 4; 0 leaves them class 2");
+SYSCTL_PROC(_kern_sched, OID_AUTO, core_class, CTLTYPE_STRING |
+    CTLFLAG_MPSAFE | CTLFLAG_RD, NULL, 0, sysctl_kern_sched_core_class, "A",
+    "Per-CPU hybrid core class (1=perf 2=eff 4=LP)");
+#endif
+
+/* ps compat.  All cpu percentages from ULE are weighted. */
+static int ccpu = 0;
+SYSCTL_INT(_kern, OID_AUTO, ccpu, CTLFLAG_RD, &ccpu, 0,
+    "Decay factor used for updating %CPU in 4BSD scheduler");

--- a/sys/sys/smp.h
+++ b/sys/sys/smp.h
@@ -108,6 +108,19 @@ typedef struct cpu_group *cpu_group_t;
 #define	CG_FLAG_NODE	0x04		/* NUMA node. */
 
 /*
+ * Heterogeneous (hybrid) core priority classes used by the SCHED_MIC
+ * scheduler.  Each logical CPU is assigned a static class; the dynamic
+ * "priority 3" (a busy core's free SMT thread) is computed at placement
+ * time and is therefore never stored.  cpu_core_class[] defaults to all
+ * CPU_CLASS_PERF, so non-hybrid (and non-x86) hardware behaves like ULE.
+ */
+#define	CPU_CLASS_PERF	1		/* P-core / AMD cache (V-Cache) CCD. */
+#define	CPU_CLASS_EFF	2		/* E-core / AMD compute CCD / C-core. */
+/* class 3 is dynamic (busy SMT sibling) and is never stored. */
+#define	CPU_CLASS_LP	4		/* Intel LP-E core (scheduled last). */
+extern uint8_t cpu_core_class[];
+
+/*
  * Convenience routines for building and traversing topologies.
  */
 #ifdef SMP

--- a/sys/x86/include/specialreg.h
+++ b/sys/x86/include/specialreg.h
@@ -522,6 +522,29 @@
 #define	CPUID_HYBRID_CORE_MASK	0xff000000
 #define	CPUID_HYBRID_SMALL_CORE	0x20000000
 #define	CPUID_HYBRID_LARGE_CORE	0x40000000
+/*
+ * Native model ID, leaf 0x1a EAX[23:0].  Model-specific; used only as a
+ * heuristic (e.g. to separate LP-E from compute-tile E-cores) and not
+ * architecturally guaranteed across SKUs.
+ */
+#define	CPUID_HYBRID_NATIVE_MODEL_MASK	0x00ffffff
+
+/*
+ * Cache property fields shared by the deterministic cache enumeration
+ * leaves (Intel leaf 0x04 and AMD leaf 0x8000001d, identical layout).
+ * The SCHED_MIC scheduler uses these to compute per-CCD L3 sizes and
+ * distinguish AMD 3D V-Cache dies from compute dies.
+ *   size in bytes = ways * partitions * line_size * sets
+ */
+#define	CPUID_CACHE_TYPE(eax)		((eax) & 0x1f)
+#define	CPUID_CACHE_LEVEL(eax)		(((eax) >> 5) & 0x7)
+#define	CPUID_CACHE_SHARING(eax)	((((eax) >> 14) & 0xfff) + 1)
+#define	CPUID_CACHE_LINE(ebx)		(((ebx) & 0xfff) + 1)
+#define	CPUID_CACHE_PARTITIONS(ebx)	((((ebx) >> 12) & 0x3ff) + 1)
+#define	CPUID_CACHE_WAYS(ebx)		((((ebx) >> 22) & 0x3ff) + 1)
+#define	CPUID_CACHE_SETS(ecx)		((ecx) + 1)
+#define	CPUID_CACHE_TYPE_NULL		0	/* no more caches */
+#define	CPUID_CACHE_TYPE_UNIFIED	3
 
 /* MSR IA32_ARCH_CAP(ABILITIES) bits */
 #define	IA32_ARCH_CAP_RDCL_NO	0x00000001

--- a/sys/x86/x86/mp_x86.c
+++ b/sys/x86/x86/mp_x86.c
@@ -960,6 +960,127 @@ cpu_topo(void)
 	return (cg_root);
 }
 
+#ifdef SCHED_MIC
+/*
+ * Hybrid-core classification for the SCHED_MIC scheduler.  Each present CPU
+ * probes its own CPUID (it must run on that CPU) to determine its core type
+ * and the size of the last-level (L3) cache it participates in; a SYSINIT run
+ * after the APs are up then derives the per-CPU class in cpu_core_class[].
+ *
+ * Detection reliability:
+ *   Intel P vs E   - architectural (CPUID 0x1a EAX[31:24]).
+ *   Intel LP-E     - heuristic: SoC-tile LP-E cores have no L3, unlike
+ *                    compute-tile E-cores; gated by kern.sched.detect_lpe.
+ *   AMD X3D / Cx   - heuristic: the CCD/CCX with the larger L3 (3D V-Cache,
+ *                    or the full-size cache of classic cores) is preferred;
+ *                    symmetric or single-CCD parts stay all-perf (== ULE).
+ */
+extern int sched_detect_lpe;
+
+static u_int	mic_hybrid[MAXCPU];	/* CPUID 0x1a core type (Intel). */
+static uint64_t	mic_l3size[MAXCPU];	/* L3 bytes this CPU shares. */
+static bool	mic_has_l3[MAXCPU];	/* Whether an L3 was found. */
+
+static uint64_t
+mic_cache_size(const u_int *regs)
+{
+
+	return ((uint64_t)CPUID_CACHE_WAYS(regs[1]) *
+	    CPUID_CACHE_PARTITIONS(regs[1]) * CPUID_CACHE_LINE(regs[1]) *
+	    CPUID_CACHE_SETS(regs[2]));
+}
+
+static void
+mic_probe_cpu(void *arg __unused)
+{
+	u_int regs[4];
+	u_int id;
+	int i, leaf;
+
+	id = PCPU_GET(cpuid);
+	mic_hybrid[id] = 0;
+	mic_l3size[id] = 0;
+	mic_has_l3[id] = false;
+
+	if (cpu_vendor_id == CPU_VENDOR_INTEL && cpu_high >= 0x1a) {
+		cpuid_count(0x1a, 0, regs);
+		mic_hybrid[id] = regs[0] & CPUID_HYBRID_CORE_MASK;
+	}
+
+	/* Deterministic cache enumeration: AMD leaf 0x8000001d, Intel 0x04. */
+	if ((cpu_vendor_id == CPU_VENDOR_AMD ||
+	    cpu_vendor_id == CPU_VENDOR_HYGON) && cpu_exthigh >= 0x8000001d)
+		leaf = 0x8000001d;
+	else if (cpu_vendor_id == CPU_VENDOR_INTEL && cpu_high >= 4)
+		leaf = 0x04;
+	else
+		return;
+
+	for (i = 0; ; i++) {
+		cpuid_count(leaf, i, regs);
+		if (CPUID_CACHE_TYPE(regs[0]) == CPUID_CACHE_TYPE_NULL)
+			break;
+		if (CPUID_CACHE_LEVEL(regs[0]) == 3) {
+			mic_l3size[id] = mic_cache_size(regs);
+			mic_has_l3[id] = true;
+			break;
+		}
+	}
+}
+
+static void
+mic_classify(void *arg __unused)
+{
+	uint64_t maxl3;
+	int i;
+	bool amd, intel, asymmetric;
+
+	if (mp_ncpus <= 1)
+		return;			/* defaults: every CPU is class perf. */
+	amd = cpu_vendor_id == CPU_VENDOR_AMD ||
+	    cpu_vendor_id == CPU_VENDOR_HYGON;
+	intel = cpu_vendor_id == CPU_VENDOR_INTEL;
+	if (!amd && !intel)
+		return;
+
+	/* Each CPU records its own type/cache; we then derive classes. */
+	smp_rendezvous(NULL, mic_probe_cpu, NULL, NULL);
+
+	if (intel) {
+		CPU_FOREACH(i) {
+			if (mic_hybrid[i] == CPUID_HYBRID_LARGE_CORE)
+				cpu_core_class[i] = CPU_CLASS_PERF;
+			else if (mic_hybrid[i] == CPUID_HYBRID_SMALL_CORE)
+				cpu_core_class[i] = (sched_detect_lpe &&
+				    !mic_has_l3[i]) ? CPU_CLASS_LP :
+				    CPU_CLASS_EFF;
+			/* Non-hybrid Intel keeps the default class perf. */
+		}
+		return;
+	}
+
+	/* AMD/Hygon: the die with the largest L3 is preferred (class perf). */
+	maxl3 = 0;
+	CPU_FOREACH(i)
+		if (mic_has_l3[i] && mic_l3size[i] > maxl3)
+			maxl3 = mic_l3size[i];
+	if (maxl3 == 0)
+		return;			/* No L3 info; leave all class perf. */
+	asymmetric = false;
+	CPU_FOREACH(i)
+		if (mic_has_l3[i] && mic_l3size[i] != maxl3) {
+			asymmetric = true;
+			break;
+		}
+	if (!asymmetric)
+		return;			/* Single CCD / symmetric L3 == ULE. */
+	CPU_FOREACH(i)
+		if (!(mic_has_l3[i] && mic_l3size[i] == maxl3))
+			cpu_core_class[i] = CPU_CLASS_EFF;
+}
+SYSINIT(mic_classify, SI_SUB_SMP, SI_ORDER_ANY, mic_classify, NULL);
+#endif /* SCHED_MIC */
+
 static void
 cpu_alloc(void *dummy __unused)
 {


### PR DESCRIPTION
## Summary

Adds **SCHED_MIC**, a new scheduler derived from ULE that weighs heterogeneous
CPU core classes when placing threads. ULE remains the GENERIC default; SCHED_MIC
is opt-in (`options SCHED_MIC`, or the sample `sys/amd64/conf/MIC` config).

On x86 hybrid CPUs it prefers cores in this order:

1. P-cores / AMD 3D V-Cache CCD cores (physical)
2. E-cores / AMD compute-CCD cores / AMD mobile "C" cores (physical)
3. the second SMT thread of a busy core ("hyperthreaded")
4. Intel LP-E cores (last)

The preference is a soft, tunable bias folded into the existing
`cpu_search_lowest()` load comparison, applied only on the placement path
(`sched_pickcpu`). The long-term balancer and work stealing stay class-blind, so
real-load balancing is preserved. On homogeneous hardware and non-x86 arches it
behaves like ULE (byte-identical with `kern.sched.smt_busy_penalty=0`).

## Detection

Per-CPU classification runs at AP startup via `smp_rendezvous` in an `SI_SUB_SMP`
SYSINIT (`#ifdef SCHED_MIC` in `mp_x86.c`), stored in a new `cpu_core_class[]`
array that defaults to "performance" (so anything unrecognized behaves like ULE):

| Case | Method | Reliability |
|---|---|---|
| Intel P vs E | CPUID `0x1A` core type | architectural |
| Intel LP-E | small core with no L3, gated by `kern.sched.detect_lpe` | heuristic |
| AMD X3D / C-cores | larger per-CCD L3 (`0x8000001D`) preferred; symmetric/single-CCD → all perf | heuristic |

## Tunables (`kern.sched.*`)

`class_weight_eff` (64), `class_weight_lp` (512), `smt_busy_penalty` (192, `0` =
stock ULE), `prefer_compute` (swap AMD cache/compute CCD), `detect_lpe`, and a
read-only `core_class` dump.

## Testing

- Both `sched_mic.c` and `mp_x86.c` build clean under `-Werror`; a MINIMAL-based
  `SCHED_MIC` kernel links into a complete kernel ELF with all symbols resolved.
- Intel detection validated against real Alder Lake silicon (Core i7-1260P): 8
  P-core threads → perf, 8 E-cores → eff, no LP-E (E-cores keep L3, so the LP
  heuristic does not misfire).
- Not yet exercised on hardware: LP-E (needs Meteor Lake / Core Ultra), AMD X3D,
  AMD C-cores, and live placement behavior (needs a booted MIC kernel).

## Notes / open questions

- The long-term balancer is class-blind by default, so under sustained saturation
  it spreads work off the preferred cores to equalize load, softening the
  placement preference. Flipping one `sched_lowest()` argument in
  `sched_balance_group` makes the balancer reinforce packing instead — a
  hardware-dependent tradeoff. See `scheduler.md` for details.
- `scheduler.md` is included at the repo root as a design doc; drop it if you'd
  rather it not live in the tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a new optional hybrid-core-aware scheduler (SCHED_MIC) derived from ULE and integrate x86 core classification, tunables, and documentation to prefer performance cores while remaining compatible with existing behavior.

New Features:
- Add the SCHED_MIC scheduler as an alternative to ULE with hybrid-core-aware thread placement.
- Classify x86 CPUs into performance, efficiency, and low-power classes using CPUID-based detection for use by the scheduler.
- Expose new sysctls and a sample amd64 kernel configuration to enable and tune SCHED_MIC behavior.
- Add a top-level scheduler.md design document describing SCHED_MIC behavior and configuration.

Enhancements:
- Extend x86 CPUID cache enumeration helpers and SMP topology structures to support hybrid core classification without changing default schedulers.