### PR TITLE
atlantic: guard rss_getkey/rss_gethashconfig with #ifdef RSS (fixes GENERIC link)

### DIFF
--- a/sys/dev/atlantic/aq_main.c
+++ b/sys/dev/atlantic/aq_main.c
@@ -412,8 +412,20 @@ aq_rss_prepare(struct aq_dev *softc, uint32_t *rss_hash_cfg)
 		return;
 	}
 
+#ifdef RSS
 	rss_getkey(softc->rss_key);
 	*rss_hash_cfg = rss_gethashconfig();
+#else
+	/*
+	 * Without the kernel RSS framework the NIC still hashes across its
+	 * queues, so generate a random key and enable the standard IPv4/IPv6
+	 * TCP and 2-tuple hash types (matching the RSS subsystem default).
+	 */
+	arc4rand(softc->rss_key, sizeof(softc->rss_key), 0);
+	*rss_hash_cfg = RSS_HASHTYPE_RSS_IPV4 | RSS_HASHTYPE_RSS_TCP_IPV4 |
+	    RSS_HASHTYPE_RSS_IPV6 | RSS_HASHTYPE_RSS_TCP_IPV6 |
+	    RSS_HASHTYPE_RSS_IPV6_EX | RSS_HASHTYPE_RSS_TCP_IPV6_EX;
+#endif
 
 #ifdef RSS
 	if (rss_gethashalgo() == RSS_HASH_TOEPLITZ) {


### PR DESCRIPTION
## Summary

`aq_rss_prepare()` in the atlantic (Aquantia/Marvell AQtion) driver calls
`rss_getkey()` and `rss_gethashconfig()` unconditionally, but those symbols only
exist when the kernel is built with `options RSS` (`net/rss_config.c` is
`optional inet rss`). The driver enables hardware RSS whenever it has more than
one RX ring (`aq_rss_enabled()` → `rx_rings_count > 1`), independent of the kernel
RSS framework, so these calls are reached in a **stock GENERIC kernel** and the
build fails to link:

```
ld: error: undefined symbol: rss_getkey
ld: error: undefined symbol: rss_gethashconfig
>>> referenced by aq_main.c:415 ... aq_if_init
```

## Fix

Guard the two calls with `#ifdef RSS`, mirroring the established pattern in
`dev/e1000/if_em.c`. Without the RSS framework, generate a random hash key with
`arc4rand()` and use the standard IPv4/IPv6 TCP + 2-tuple hash types (the RSS
subsystem default), so the NIC still distributes traffic across its queues. The
already-`#ifdef RSS`-guarded indirection-table logic below is unchanged.

## Testing

- `aq_main.o` compiles clean under a no-RSS (GENERIC) config.
- A full **GENERIC** kernel now builds and links (33 MB kernel ELF, no undefined
  symbols) — it previously failed at link as shown above.

This is an independent build fix (no functional change when `options RSS` is set).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Guard atlantic driver RSS configuration against builds without the kernel RSS framework to restore GENERIC kernel linkability.

Bug Fixes:
- Prevent undefined symbol link errors in the atlantic driver when the kernel is built without options RSS by conditionally compiling RSS framework calls.

Enhancements:
- Provide a fallback RSS key and default IPv4/IPv6 TCP and 2-tuple hash configuration when the kernel RSS framework is disabled so hardware RSS remains effective.