### PR TITLE
mport: fix upgrade.c ohash callback signatures after ohash update

### DIFF
--- a/contrib/mport/libmport/upgrade.c
+++ b/contrib/mport/libmport/upgrade.c
@@ -43,22 +43,21 @@
 #include <ohash.h>
 #endif
 
-static void *ecalloc(size_t, void *);
-static void efree(void *, size_t, void *);
+static void *ecalloc(size_t, size_t, void *);
+static void efree(void *, void *);
 
 static void *
-ecalloc(size_t s1, void *data)
+ecalloc(size_t s1, size_t s2, void *data)
 {
 	void *p;
 
-	if (!(p = malloc(s1)))
-		err(1, "malloc");
-	memset(p, 0, s1);
+	if (!(p = calloc(s1, s2)))
+		err(1, "calloc");
 	return p;
 }
 
 static void
-efree(void *p, size_t s1, void *data)
+efree(void *p, void *data)
 {
 	free(p);
 }


### PR DESCRIPTION
## Summary

- `ecalloc` updated from `(size_t, void *)` to `(size_t, size_t, void *)` to match the new `ohash_info.calloc` signature; implementation switched from `malloc`+`memset` to `calloc`
- `efree` updated from `(void *, size_t, void *)` to `(void *, void *)` to match the new `ohash_info.free` signature
- Forward declarations updated to match

Fixes build errors introduced after `lib/libc/ohash` was updated:
```
upgrade.c:73:38: error: incompatible function pointer types initializing
  'void *(*)(size_t, size_t, void *)' with 'void *(size_t, void *)'
upgrade.c:73:47: error: incompatible function pointer types initializing
  'void (*)(void *, void *)' with 'void (void *, size_t, void *)'
```

## Test plan

- [ ] `cd contrib/mport/libmport && make` — confirm `upgrade.o` compiles without errors
- [ ] `make buildworld` — confirm no regression in full build

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Correct ecalloc and efree callback signatures and behavior to match the new ohash_info.calloc and ohash_info.free interfaces, resolving compilation errors after the ohash library update.