### PR TITLE
Makefile.inc1: fix intermittent libmagic build failure under high parallelism

### DIFF
--- a/Makefile.inc1
+++ b/Makefile.inc1
@@ -3168,6 +3168,7 @@ lib/libsqlite3__L: lib/libthr__L lib/msun__L lib/libz__L
 lib/libdns_sd__L: lib/libthr__L
 lib/libnss_mdns__L: lib/dns_sd__L lib/libthr__L
 
+lib/libmagic__L: lib/libz__L
 lib/libucl__L: lib/msun__L
 
 .if ${MK_GSSAPI} != "no"


### PR DESCRIPTION
## Summary

- Adds missing `lib/libmagic__L: lib/libz__L` dependency in `Makefile.inc1`
- `lib/libmagic/Makefile` has `LIBADD= z` so libmagic must link `-lz`, but no `__L` ordering constraint was declared
- Under `-j28` (or any high `-j`), the linker step for `libmagic.so.4.full` could race ahead of `libz` being installed into the sysroot

**Observed failure:**
```
ld: error: unable to find library -lz
cc: error: linker command failed with exit code 1
*** [libmagic.so.4.full] Error code 1
make[4]: stopped in /usr/src/lib/libmagic
```

All other libraries that depend on libz already have explicit `__L` constraints (`lib/libarchive__L`, `secure/lib/libssh__L`, `cddl/lib/libzfs__L`, `lib/libsqlite3__L`, etc.). libmagic was simply overlooked.

## Test plan

- [ ] `make -j28 buildworld` on amd64 — confirm `lib/libmagic` builds cleanly without the race
- [ ] `make -j4 buildworld` — confirm no regression at lower parallelism

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a missing build dependency to ensure libmagic links against libz reliably under high parallelism.

Bug Fixes:
- Prevent intermittent libmagic link failures when building with high make parallelism by enforcing proper libz dependency ordering.

Build:
- Declare libmagic's dependency on libz in Makefile.inc1 to guarantee correct build ordering in parallel builds.