### PR TITLE
Makefile.inc1: fix intermittent libmagic build failure under high parallelism

### DIFF
--- a/Makefile.inc1
+++ b/Makefile.inc1
@@ -3172,6 +3172,7 @@ lib/libsqlite3__L: lib/libthr__L lib/msun__L lib/libz__L
 lib/libdns_sd__L: lib/libthr__L
 lib/libnss_mdns__L: lib/dns_sd__L lib/libthr__L
 
+lib/libmagic__L: lib/libz__L
 lib/libucl__L: lib/msun__L
 
 .if ${MK_GSSAPI} != "no"


### PR DESCRIPTION
## Summary

- Adds missing `lib/libmagic__L: lib/libz__L` dependency in `Makefile.inc1`
- `lib/libmagic/Makefile` has `LIBADD= z` but no `__L` ordering constraint was declared
- Under high parallelism (`make -j28`) the linker step for `libmagic.so.4.full` can race ahead of `libz` being installed into the sysroot

**Observed failure:**
```
ld: error: unable to find library -lz
cc: error: linker command failed with exit code 1
*** [libmagic.so.4.full] Error code 1
```

Same fix already merged to stable/4.0 in PR #399.

## Test plan

- [ ] `make -j28 buildworld` on amd64 — confirm `lib/libmagic` builds cleanly
- [ ] `make -j4 buildworld` — confirm no regression at lower parallelism

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Add an explicit libmagic-to-libz dependency to ensure libmagic linking does not race ahead of libz installation during parallel builds.