### PR TITLE
batt: distinguish AC line status values

### DIFF
--- a/usr.bin/batt/batt.c
+++ b/usr.bin/batt/batt.c
@@ -108,12 +108,19 @@ main(int argc, char *argv[])
 					errx(1, "AC line status not available");
 				else if (len != sizeof(acline))
 					errx(1, "unexpected AC line status value size");
-				else {
-					if (acline == 1)
+				else
+					switch (acline) {
+					case 0:
+						puts("System running on battery power");
+						break;
+					case 1:
 						puts("System plugged in");
-					else
-						printf("Battery charging or drained.\n");
-				}
+						break;
+					case -1:
+						errx(1, "AC line status unknown");
+					default:
+						errx(1, "unexpected AC line status value");
+					}
 			} else if (time == 1)
 				printf("1 minute remaining\n");
 			else

--- a/usr.bin/batt/tests/batt_test.c
+++ b/usr.bin/batt/tests/batt_test.c
@@ -176,7 +176,10 @@ run_batt(size_t argc, const char *const *args)
 		close(errpipe[1]);
 		optind = 1;
 		opterr = 1;
-		_exit(batt_main((int)argc, argv));
+		status = batt_main((int)argc, argv);
+		if (fflush(stdout) == EOF)
+			_exit(127);
+		_exit(status);
 	}
 
 	for (i = 0; i < argc; i++)
@@ -262,6 +265,66 @@ ATF_TC_BODY(acline_status, tc)
 	free_result(&result);
 }
 
+ATF_TC_WITHOUT_HEAD(battery_power_status);
+ATF_TC_BODY(battery_power_status, tc)
+{
+	const char *const argv[] = { "batt", "-t", NULL };
+	struct run_result result;
+
+	(void)tc;
+
+	reset_mocks();
+	add_mock("hw.acpi.battery.time", 0, sizeof(int), 0);
+	add_mock("hw.acpi.acline", 0, sizeof(int), 0);
+
+	result = run_batt(2, argv);
+	ATF_CHECK_EQ(result.exit_status, 0);
+	ATF_CHECK_STREQ(result.stdout_data,
+	    "System running on battery power\n");
+	ATF_CHECK_STREQ(result.stderr_data, "");
+	free_result(&result);
+}
+
+ATF_TC_WITHOUT_HEAD(unknown_acline_status);
+ATF_TC_BODY(unknown_acline_status, tc)
+{
+	const char *const argv[] = { "batt", "-t", NULL };
+	struct run_result result;
+
+	(void)tc;
+
+	reset_mocks();
+	add_mock("hw.acpi.battery.time", 0, sizeof(int), 0);
+	add_mock("hw.acpi.acline", -1, sizeof(int), 0);
+
+	result = run_batt(2, argv);
+	ATF_CHECK_EQ(result.exit_status, 1);
+	ATF_CHECK_STREQ(result.stdout_data, "");
+	ATF_CHECK(strstr(result.stderr_data,
+	    "AC line status unknown") != NULL);
+	free_result(&result);
+}
+
+ATF_TC_WITHOUT_HEAD(invalid_acline_status);
+ATF_TC_BODY(invalid_acline_status, tc)
+{
+	const char *const argv[] = { "batt", "-t", NULL };
+	struct run_result result;
+
+	(void)tc;
+
+	reset_mocks();
+	add_mock("hw.acpi.battery.time", 0, sizeof(int), 0);
+	add_mock("hw.acpi.acline", 2, sizeof(int), 0);
+
+	result = run_batt(2, argv);
+	ATF_CHECK_EQ(result.exit_status, 1);
+	ATF_CHECK_STREQ(result.stdout_data, "");
+	ATF_CHECK(strstr(result.stderr_data,
+	    "unexpected AC line status value") != NULL);
+	free_result(&result);
+}
+
 ATF_TC_WITHOUT_HEAD(extra_argument);
 ATF_TC_BODY(extra_argument, tc)
 {
@@ -323,6 +386,9 @@ ATF_TP_ADD_TCS(tp)
 	ATF_TP_ADD_TC(tp, default_output);
 	ATF_TP_ADD_TC(tp, concise_all_flags);
 	ATF_TP_ADD_TC(tp, acline_status);
+	ATF_TP_ADD_TC(tp, battery_power_status);
+	ATF_TP_ADD_TC(tp, unknown_acline_status);
+	ATF_TP_ADD_TC(tp, invalid_acline_status);
 	ATF_TP_ADD_TC(tp, extra_argument);
 	ATF_TP_ADD_TC(tp, short_life_sysctl);
 	ATF_TP_ADD_TC(tp, short_acline_sysctl);


### PR DESCRIPTION
## Summary

- report AC-line value 0 as battery power and value 1 as plugged in
- diagnose the kernel sentinel value -1 as unknown and reject other values
- flush captured stdout in the test child before `_exit()`
- add regression coverage for offline, unknown, and invalid AC-line values

## Testing

- `bmake -C usr.bin/batt clean all`
- `kyua test -k /usr/obj/usr/src/amd64.amd64/usr.bin/batt/tests/Kyuafile` (9/9 passed)
- `git diff --cached --check -- usr.bin/batt`

The repository C-analysis scripts were invoked. Their `\.c$` filter skipped clang-tidy and Splint, so both were also run manually. Splint cannot parse the current system headers; clang-tidy/cppcheck reported pre-existing diagnostics in batt and its test harness, with no diagnostic specific to the new AC-line switch.

AI-Assisted-by: GPT-5.6 (Codex)

## Summary by Sourcery

Handle AC-line status values explicitly and add regression coverage for valid, unknown, and invalid states.

New Features:
- Distinguish battery-powered, plugged-in, unknown, and invalid AC-line status values in batt output.

Bug Fixes:
- Treat the kernel AC-line sentinel value -1 as an explicit error instead of reporting a charging or drained state.

Enhancements:
- Flush captured child-process stdout before exiting to ensure test output is preserved.

Tests:
- Add regression coverage for battery-power, unknown, and invalid AC-line statuses.