### PR TITLE
usr.bin: add flock and ts utilities

### DIFF
--- a/contrib/ts/ts.1
+++ b/contrib/ts/ts.1
@@ -1,0 +1,105 @@
+.\"\t$OpenBSD: ts.1,v 1.6 2022/06/30 21:40:41 jmc Exp $
+.\"
+.\" Copyright (c) 2022 Job Snijders <job@openbsd.org>
+.\"
+.\" Permission to use, copy, modify, and distribute this software for any
+.\" purpose with or without fee is hereby granted, provided that the above
+.\" copyright notice and this permission notice appear in all copies.
+.\"
+.\" THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+.\" WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+.\" MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+.\" ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+.\" WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+.\" ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+.\" OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+.\"
+.Dd June 30, 2022
+.Dt TS 1
+.Os
+.Sh NAME
+.Nm ts
+.Nd timestamp input
+.Sh SYNOPSIS
+.Nm
+.Op Fl i | s
+.Op Fl m
+.Op Ar format
+.Sh DESCRIPTION
+The
+.Nm
+utility prepends a timestamp to each line of standard input and writes
+it to standard output.
+.Pp
+The options are as follows:
+.Bl -tag -width Ds
+.It Fl i
+Display time elapsed since the last timestamp.
+.It Fl m
+Display timestamps derived from a strictly linearly increasing clock.
+Without
+.Fl m ,
+timestamps reflect the current date and time, including time jumps if the
+system time is changed.
+.It Fl s
+Display time elapsed since the start of the program.
+.El
+.Pp
+The optional
+.Ar format
+argument controls how the timestamp is displayed, according to the conversion
+specifications described in the
+.Xr strftime 3
+manual page.
+The default format is
+.Qq %b %d %H:%M:%S ;
+or
+.Qq %H:%M:%S
+if one of the
+.Fl i
+or
+.Fl s
+options is used.
+.Pp
+Some additional conversion specifications are also supported
+to append microsecond resolution:
+.Cm %.S ,
+.Cm %.s ,
+and
+.Cm %.T ;
+which are similar to
+.Cm %S ,
+.Cm %s ,
+and
+.Cm \&%T .
+.Sh EXAMPLES
+.Bd -literal -offset indent
+$ (echo foo; sleep 2; echo bar) | ts
+Jun 28 12:13:38 foo
+Jun 28 12:13:40 bar
+
+$ ls | ts -i %.S
+00.000452 CVS
+00.000595 Makefile
+.Ed
+.Sh SEE ALSO
+.Xr strftime 3
+.Sh HISTORY
+A
+.Nm
+utility first appeared in the moreutils collection by Joey Hess, and was
+rewritten from scratch for
+.Ox 7.2 .
+.Pp
+It was imported to
+.Fx
+by
+.An -nosplit
+.An Juraj Lutter Aq Mt otis@FreeBSD.org .
+.Sh AUTHORS
+This
+.Nm
+utility was written by
+.An Job Snijders Aq Mt job@openbsd.org
+and
+.An Claudio Jeker Aq Mt claudio@openbsd.org .

--- a/contrib/ts/ts.c
+++ b/contrib/ts/ts.c
@@ -1,0 +1,208 @@
+/*	$OpenBSD: ts.c,v 1.7 2022/07/06 07:59:03 claudio Exp $	*/
+/*
+ * Copyright (c) 2022 Job Snijders <job@openbsd.org>
+ * Copyright (c) 2022 Claudio Jeker <claudio@openbsd.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <sys/types.h>
+#include <sys/time.h>
+
+#include <err.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+
+static const char	*format = "%b %d %H:%M:%S";
+static char		*buf;
+static char		*outbuf;
+static size_t		 bufsize;
+
+static void		 fmtfmt(const struct timespec *);
+static size_t		 format_length(const char *);
+static void __dead2 usage(void);
+
+int
+main(int argc, char *argv[])
+{
+	int iflag, mflag, sflag;
+	int ch, prev;
+	struct timespec start, now, utc_offset, ts;
+	clockid_t clock = CLOCK_REALTIME;
+
+	iflag = mflag = sflag = 0;
+
+	while ((ch = getopt(argc, argv, "ims")) != -1) {
+		switch (ch) {
+		case 'i':
+			iflag = 1;
+			format = "%H:%M:%S";
+			clock = CLOCK_MONOTONIC;
+			break;
+		case 'm':
+			mflag = 1;
+			clock = CLOCK_MONOTONIC;
+			break;
+		case 's':
+			sflag = 1;
+			format = "%H:%M:%S";
+			clock = CLOCK_MONOTONIC;
+			break;
+		default:
+			usage();
+		}
+	}
+	argc -= optind;
+	argv += optind;
+
+	if ((iflag && sflag) || argc > 1)
+		usage();
+
+	if (argc == 1)
+		format = *argv;
+
+	bufsize = format_length(format) * 10;
+	if (bufsize == 0)
+		bufsize = 1;
+	if ((buf = calloc(1, bufsize)) == NULL)
+		err(1, NULL);
+	if ((outbuf = calloc(1, bufsize)) == NULL)
+		err(1, NULL);
+
+	/* Force UTC for interval calculations. */
+	if (iflag || sflag) {
+		if (setenv("TZ", "UTC", 1) == -1)
+			err(1, "setenv UTC");
+	}
+
+	if (clock_gettime(clock, &start) == -1)
+		err(1, "clock_gettime");
+	if (clock_gettime(CLOCK_REALTIME, &utc_offset) == -1)
+		err(1, "clock_gettime");
+	timespecsub(&utc_offset, &start, &utc_offset);
+
+	for (prev = '\n'; (ch = getchar()) != EOF; prev = ch) {
+		if (prev == '\n') {
+			if (clock_gettime(clock, &now) == -1)
+				err(1, "clock_gettime");
+			if (iflag || sflag)
+				timespecsub(&now, &start, &ts);
+			else if (mflag)
+				timespecadd(&now, &utc_offset, &ts);
+			else
+				ts = now;
+			fmtfmt(&ts);
+			if (iflag)
+				start = now;
+		}
+		if (putchar(ch) == EOF)
+			break;
+	}
+	if (ferror(stdin))
+		err(1, "stdin");
+
+	if (fclose(stdout) == EOF)
+		err(1, "stdout");
+	free(outbuf);
+	free(buf);
+	return (0);
+}
+
+static void __dead2
+usage(void)
+{
+
+	fprintf(stderr, "usage: %s [-i | -s] [-m] [format]\n", getprogname());
+	exit(1);
+}
+
+static void
+fmtfmt(const struct timespec *ts)
+{
+	struct tm tm;
+	char *f, us[7];
+	long usec;
+	size_t format_len, i;
+
+	if (localtime_r(&ts->tv_sec, &tm) == NULL)
+		err(1, "localtime");
+
+	if (ts->tv_nsec < 0 || ts->tv_nsec >= 1000000000L)
+		errx(1, "invalid nanosecond value");
+	usec = ts->tv_nsec / 1000;
+	us[6] = '\0';
+	for (i = 6; i > 0; i--) {
+		us[i - 1] = (char)('0' + usec % 10);
+		usec /= 10;
+	}
+	format_len = format_length(format);
+	for (i = 0; i <= format_len; i++)
+		buf[i] = format[i];
+	f = buf;
+
+	do {
+		while (*f != '\0') {
+			if (*f != '%') {
+				f++;
+				continue;
+			}
+			if (f[1] == '%') {
+				f += 2;
+				continue;
+			}
+			break;
+		}
+		if (*f == '\0')
+			break;
+
+		f++;
+		if (f[0] == '.' &&
+		    (f[1] == 'S' || f[1] == 's' || f[1] == 'T')) {
+			size_t len, offset;
+
+			f[0] = f[1];
+			f[1] = '.';
+			f += 2;
+			len = format_length(f);
+			offset = (size_t)(f - buf);
+			if (offset > bufsize || bufsize - offset < len + 7)
+				errx(1, "expanded format string too big");
+			for (i = len + 1; i > 0; i--)
+				f[i + 5] = f[i - 1];
+			for (i = 0; i < 6; i++)
+				f[i] = us[i];
+			f += 6;
+		}
+	} while (*f != '\0');
+
+	if (strftime(outbuf, bufsize, buf, &tm) == 0 && buf[0] != '\0')
+		errx(1, "strftime");
+	if (fprintf(stdout, "%s ", outbuf) < 0)
+		err(1, "stdout");
+}
+
+static size_t
+format_length(const char *str)
+{
+	size_t len;
+
+	for (len = 0; str[len] != '\0'; len++) {
+		if (len >= SIZE_MAX / 10)
+			errx(1, "format string too big");
+	}
+	return (len);
+}

--- a/usr.bin/Makefile
+++ b/usr.bin/Makefile
@@ -50,6 +50,7 @@ SUBDIR=	alias \
 	false \
 	fetch \
 	find \
+	flock \
 	fmt \
 	fold \
 	fstat \
@@ -176,6 +177,7 @@ SUBDIR=	alias \
 	touch \
 	tput \
 	tr \
+	ts \
 	true \
 	truncate \
 	tset \

--- a/usr.bin/flock/Makefile
+++ b/usr.bin/flock/Makefile
@@ -1,0 +1,8 @@
+.include <src.opts.mk>
+
+PROG=	flock
+
+HAS_TESTS=
+SUBDIR.${MK_TESTS}+=	tests
+
+.include <bsd.prog.mk>

--- a/usr.bin/flock/Makefile
+++ b/usr.bin/flock/Makefile
@@ -1,6 +1,7 @@
 .include <src.opts.mk>
 
 PROG=	flock
+MAN=	flock.1
 
 HAS_TESTS=
 SUBDIR.${MK_TESTS}+=	tests

--- a/usr.bin/flock/flock.1
+++ b/usr.bin/flock/flock.1
@@ -1,0 +1,103 @@
+.\"\t$NetBSD: flock.1,v 1.13 2019/10/04 16:14:05 uwe Exp $
+.\"
+.\" Copyright (c) 2012 The NetBSD Foundation, Inc.
+.\" All rights reserved.
+.\"
+.\" This code is derived from software contributed to The NetBSD Foundation
+.\" by Christos Zoulas.
+.\"
+.\" Redistribution and use in source and binary forms, with or without
+.\" modification, are permitted provided that the following conditions
+.\" are met:
+.\" 1. Redistributions of source code must retain the above copyright
+.\"    notice, this list of conditions and the following disclaimer.
+.\" 2. Redistributions in binary form must reproduce the above copyright
+.\"    notice, this list of conditions and the following disclaimer in the
+.\"    documentation and/or other materials provided with the distribution.
+.\"
+.\" THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+.\" ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+.\" TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+.\" PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+.\" BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+.\" CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+.\" SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+.\" INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+.\" CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+.\" ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+.\" POSSIBILITY OF SUCH DAMAGE.
+.\"
+.Dd September 9, 2026
+.Dt FLOCK 1
+.Os
+.Sh NAME
+.Nm flock
+.Nd provide locking for shell scripts
+.Sh SYNOPSIS
+.Nm
+.Op Fl dhnosvx
+.Op Fl w Ar timeout
+.Ar file Ns | Ns Ar directory
+.Ar command
+.Op Ar args ...
+.Nm
+.Op Fl dhnosvx
+.Op Fl w Ar timeout
+.Ar file Ns | Ns Ar directory
+.Fl c Ar command
+.Nm
+.Op Fl dhnsuvx
+.Op Fl w Ar timeout
+.Ar number
+.Sh DESCRIPTION
+The
+.Nm
+utility provides
+.Xr flock 2
+access to commands and shell scripts.
+The first two forms lock the specified file or directory while the provided
+command executes.
+If the path does not exist, a file is created with mode 0600.
+.Pp
+The third form locks an open file descriptor supplied by a shell script.
+.Pp
+The options are as follows:
+.Bl -tag -width timeout
+.It Fl c Ar command
+Pass
+.Ar command
+to the shell.
+.It Fl d , Fl Fl debug
+Print debugging information.
+.It Fl h , Fl Fl help
+Print usage information.
+.It Fl n , Fl Fl nb , Fl Fl nonblock
+Fail immediately if the lock cannot be obtained.
+.It Fl o , Fl Fl close
+Close the lock file descriptor before executing the command.
+.It Fl s , Fl Fl shared
+Obtain a shared lock.
+.It Fl u , Fl Fl unlock
+Unlock an existing lock.
+This is valid only for a file descriptor.
+.It Fl v , Fl Fl verbose
+Print an explanation when locking fails.
+.It Fl w Ar timeout , Fl Fl wait Ar timeout , Fl Fl timeout Ar timeout
+Fail if the lock cannot be obtained within the specified, possibly fractional,
+number of seconds.
+A timeout of zero is equivalent to
+.Fl n .
+.It Fl x , Fl Fl exclusive
+Obtain an exclusive lock.
+This is the default.
+.El
+.Sh EXIT STATUS
+.Ex -std
+.Sh SEE ALSO
+.Xr lockf 1 ,
+.Xr flock 2
+.Sh HISTORY
+A
+.Nm
+utility appeared in
+.Nx 6.1 .

--- a/usr.bin/flock/flock.c
+++ b/usr.bin/flock/flock.c
@@ -1,0 +1,323 @@
+/*	$NetBSD: flock.c,v 1.12 2019/10/04 16:27:00 mrg Exp $	*/
+
+/*-
+ * Copyright (c) 2012 The NetBSD Foundation, Inc.
+ * All rights reserved.
+ *
+ * This code is derived from software contributed to The NetBSD Foundation
+ * by Christos Zoulas.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <sys/cdefs.h>
+#include <sys/file.h>
+#include <sys/time.h>
+
+#include <err.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <getopt.h>
+#include <limits.h>
+#include <math.h>
+#include <paths.h>
+#include <signal.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+static const struct option flock_longopts[] = {
+	{ "debug", no_argument, NULL, 'd' },
+	{ "help", no_argument, NULL, 'h' },
+	{ "nonblock", no_argument, NULL, 'n' },
+	{ "nb", no_argument, NULL, 'n' },
+	{ "close", no_argument, NULL, 'o' },
+	{ "shared", no_argument, NULL, 's' },
+	{ "exclusive", no_argument, NULL, 'x' },
+	{ "unlock", no_argument, NULL, 'u' },
+	{ "verbose", no_argument, NULL, 'v' },
+	{ "wait", required_argument, NULL, 'w' },
+	{ "timeout", required_argument, NULL, 'w' },
+	{ NULL, 0, NULL, 0 },
+};
+
+static volatile sig_atomic_t timeout_expired;
+
+static char	lockchar(int);
+static const char *lockname(int);
+static int	option_is_command(const char *);
+static void	sigalrm(int);
+static void	start_timer(double);
+static void	stop_timer(void);
+static void __dead2 __printflike(1, 2) usage(const char *, ...);
+
+static void __dead2
+usage(const char *fmt, ...)
+{
+	va_list ap;
+
+	if (fmt != NULL) {
+		va_start(ap, fmt);
+		fprintf(stderr, "%s: ", getprogname());
+		vfprintf(stderr, fmt, ap);
+		fputc('\n', stderr);
+		va_end(ap);
+	}
+	fprintf(stderr,
+	    "usage: %s [-dhnosvx] [-w timeout] file|directory "
+	    "command [args ...]\n"
+	    "       %s [-dhnosvx] [-w timeout] file|directory "
+	    "-c command\n"
+	    "       %s [-dhnsuvx] [-w timeout] number\n",
+	    getprogname(), getprogname(), getprogname());
+	exit(EXIT_FAILURE);
+}
+
+static void
+sigalrm(int signo)
+{
+
+	(void)signo;
+	timeout_expired = 1;
+}
+
+static void
+start_timer(double timeout)
+{
+	struct itimerval timer;
+	struct sigaction sa;
+	double fraction;
+
+	timerclear(&timer.it_interval);
+	timer.it_value.tv_sec = (time_t)timeout;
+	fraction = timeout - (double)timer.it_value.tv_sec;
+	timer.it_value.tv_usec = (suseconds_t)(fraction * 1000000.0);
+	if (!timerisset(&timer.it_value))
+		timer.it_value.tv_usec = 1;
+
+	sa.sa_handler = sigalrm;
+	sigemptyset(&sa.sa_mask);
+	sa.sa_flags = 0;
+	if (sigaction(SIGALRM, &sa, NULL) == -1)
+		err(EXIT_FAILURE, "sigaction");
+	if (setitimer(ITIMER_REAL, &timer, NULL) == -1)
+		err(EXIT_FAILURE, "setitimer");
+}
+
+static void
+stop_timer(void)
+{
+	struct itimerval timer;
+
+	timerclear(&timer.it_interval);
+	timerclear(&timer.it_value);
+	if (setitimer(ITIMER_REAL, &timer, NULL) == -1)
+		err(EXIT_FAILURE, "setitimer");
+}
+
+static const char *
+lockname(int lock)
+{
+
+	switch (lock & ~LOCK_NB) {
+	case LOCK_SH:
+		return ((lock & LOCK_NB) != 0 ? "shared, nonblocking" :
+		    "shared");
+	case LOCK_EX:
+		return ((lock & LOCK_NB) != 0 ? "exclusive, nonblocking" :
+		    "exclusive");
+	case LOCK_UN:
+		return ((lock & LOCK_NB) != 0 ? "unlock, nonblocking" :
+		    "unlock");
+	default:
+		return ("invalid");
+	}
+}
+
+static char
+lockchar(int lock)
+{
+
+	switch (lock & ~LOCK_NB) {
+	case LOCK_SH:
+		return ('s');
+	case LOCK_EX:
+		return ('x');
+	case LOCK_UN:
+		return ('u');
+	default:
+		return ('?');
+	}
+}
+
+static int
+option_is_command(const char *arg)
+{
+
+	return ((arg[0] == '-' && arg[1] == 'c' && arg[2] == '\0') ||
+	    (arg[0] == '-' && arg[1] == '-' && arg[2] == 'c' &&
+	    arg[3] == 'o' && arg[4] == 'm' && arg[5] == 'm' &&
+	    arg[6] == 'a' && arg[7] == 'n' && arg[8] == 'd' &&
+	    arg[9] == '\0'));
+}
+
+int
+main(int argc, char *argv[])
+{
+	char *end;
+	char *shell_argv[] = { _PATH_BSHELL, "-c", NULL, NULL };
+	char **cmdargv;
+	double timeout;
+	long descriptor;
+	int ch, closefd, debug, fd, lock, timer_started, timeout_set, verbose;
+
+	closefd = debug = timeout_set = verbose = 0;
+	cmdargv = NULL;
+	fd = -1;
+	lock = 0;
+	timeout = 0.0;
+	timer_started = 0;
+
+	while ((ch = getopt_long(argc, argv, "+dhnosuvw:x",
+	    flock_longopts, NULL)) != -1) {
+		switch (ch) {
+		case 'd':
+			debug = 1;
+			break;
+		case 'h':
+			usage(NULL);
+		case 'n':
+			lock |= LOCK_NB;
+			break;
+		case 'o':
+			closefd = 1;
+			break;
+		case 's':
+			if ((lock & ~LOCK_NB) != 0 &&
+			    (lock & ~LOCK_NB) != LOCK_SH) {
+				usage("-%c cannot be used with -s",
+				    lockchar(lock));
+			}
+			lock |= LOCK_SH;
+			break;
+		case 'u':
+			if ((lock & ~LOCK_NB) != 0 &&
+			    (lock & ~LOCK_NB) != LOCK_UN) {
+				usage("-%c cannot be used with -u",
+				    lockchar(lock));
+			}
+			lock |= LOCK_UN;
+			break;
+		case 'v':
+			verbose = 1;
+			break;
+		case 'w':
+			errno = 0;
+			timeout = strtod(optarg, &end);
+			if (errno == ERANGE || end == optarg || *end != '\0' ||
+			    !isfinite(timeout) || timeout < 0.0 ||
+			    timeout > (double)INT_MAX)
+				usage("invalid timeout: %s", optarg);
+			timeout_set = 1;
+			break;
+		case 'x':
+			if ((lock & ~LOCK_NB) != 0 &&
+			    (lock & ~LOCK_NB) != LOCK_EX) {
+				usage("-%c cannot be used with -x",
+				    lockchar(lock));
+			}
+			lock |= LOCK_EX;
+			break;
+		default:
+			usage(NULL);
+		}
+	}
+	argc -= optind;
+	argv += optind;
+
+	if ((lock & ~LOCK_NB) == 0)
+		lock |= LOCK_EX;
+	if (timeout_set && timeout == 0.0)
+		lock |= LOCK_NB;
+
+	if (argc == 0)
+		usage("missing lock file or descriptor");
+	if (argc == 1) {
+		if (closefd)
+			usage("-o is not valid for a descriptor");
+		errno = 0;
+		descriptor = strtol(argv[0], &end, 0);
+		if (errno == ERANGE || end == argv[0] || *end != '\0' ||
+		    descriptor < 0 || descriptor > INT_MAX)
+			errx(EXIT_FAILURE, "invalid file descriptor: %s",
+			    argv[0]);
+		fd = (int)descriptor;
+	} else {
+		if ((lock & ~LOCK_NB) == LOCK_UN)
+			usage("-u is valid only for a descriptor");
+		if (option_is_command(argv[1])) {
+			if (argc != 3)
+				usage("-c requires one command argument");
+			shell_argv[2] = argv[2];
+			cmdargv = shell_argv;
+		} else {
+			cmdargv = argv + 1;
+		}
+		fd = open(argv[0], O_RDONLY);
+		if (fd == -1 && errno == ENOENT)
+			fd = open(argv[0], O_RDWR | O_CREAT, 0600);
+		if (fd == -1)
+			err(EXIT_FAILURE, "%s", argv[0]);
+	}
+
+	if (debug) {
+		if (cmdargv == NULL)
+			fprintf(stderr, "descriptor %d: %s lock\n", fd,
+			    lockname(lock));
+		else
+			fprintf(stderr, "%s: %s lock; command %s\n", argv[0],
+			    lockname(lock), cmdargv[0]);
+	}
+
+	if (timeout_set && timeout > 0.0 && (lock & LOCK_NB) == 0) {
+		start_timer(timeout);
+		timer_started = 1;
+	}
+	while (flock(fd, lock) == -1) {
+		if (errno == EINTR && !timeout_expired)
+			continue;
+		if (verbose)
+			err(EXIT_FAILURE, "flock(%d, %s)", fd, lockname(lock));
+		return (EXIT_FAILURE);
+	}
+	if (timer_started)
+		stop_timer();
+
+	if (closefd && close(fd) == -1)
+		err(EXIT_FAILURE, "close");
+	if (cmdargv != NULL) {
+		execvp(cmdargv[0], cmdargv);
+		err(EXIT_FAILURE, "%s", cmdargv[0]);
+	}
+	return (EXIT_SUCCESS);
+}

--- a/usr.bin/flock/tests/Makefile
+++ b/usr.bin/flock/tests/Makefile
@@ -1,0 +1,5 @@
+PACKAGE=	tests
+
+ATF_TESTS_SH=	flock_test
+
+.include <bsd.test.mk>

--- a/usr.bin/flock/tests/flock_test.sh
+++ b/usr.bin/flock/tests/flock_test.sh
@@ -1,0 +1,92 @@
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+
+atf_test_case command
+command_head()
+{
+	atf_set "descr" "run a command while holding a lock"
+}
+command_body()
+{
+	atf_check -s exit:0 -e empty -o inline:"locked\n" \
+	    flock lock printf "locked\n"
+	atf_check -s exit:0 -e empty -o empty test -f lock
+}
+
+atf_test_case shell_command
+shell_command_head()
+{
+	atf_set "descr" "run an explicit shell command"
+}
+shell_command_body()
+{
+	atf_check -s exit:0 -e empty -o inline:"shell command\n" \
+	    flock lock -c "printf 'shell command\\n'"
+}
+
+atf_test_case exit_status
+exit_status_head()
+{
+	atf_set "descr" "preserve the executed command exit status"
+}
+exit_status_body()
+{
+	atf_check -s exit:7 -e empty -o empty flock lock sh -c "exit 7"
+}
+
+atf_test_case nonblocking
+nonblocking_head()
+{
+	atf_set "descr" "fail rather than block when a lock is held"
+}
+nonblocking_cleanup()
+{
+	if [ -f holder.pid ]; then
+		kill "$(cat holder.pid)" 2>/dev/null || true
+	fi
+}
+nonblocking_body()
+{
+	flock lock tail -f /dev/null &
+	holder=$!
+	printf "%s\n" "${holder}" >holder.pid
+	held=false
+	for attempt in 1 2 3 4 5; do
+		if ! flock -n lock true; then
+			held=true
+			break
+		fi
+		sleep 1
+	done
+	if [ "${held}" != true ]; then
+		atf_fail "lock holder did not start"
+	fi
+
+	atf_check -s exit:1 -e empty -o empty flock -n lock true
+	kill "${holder}" 2>/dev/null || true
+	wait "${holder}" 2>/dev/null || true
+	rm holder.pid
+}
+
+atf_test_case invalid_timeout
+invalid_timeout_head()
+{
+	atf_set "descr" "reject malformed and negative timeout values"
+}
+invalid_timeout_body()
+{
+	atf_check -s exit:1 -e match:"invalid timeout" -o empty \
+	    flock -w invalid lock true
+	atf_check -s exit:1 -e match:"invalid timeout" -o empty \
+	    flock -w -1 lock true
+}
+
+atf_init_test_cases()
+{
+	atf_add_test_case command
+	atf_add_test_case shell_command
+	atf_add_test_case exit_status
+	atf_add_test_case nonblocking
+	atf_add_test_case invalid_timeout
+}

--- a/usr.bin/shuf/shuf.c
+++ b/usr.bin/shuf/shuf.c
@@ -410,5 +410,5 @@ out:
 	if (oflag)
 		fclose(ofile);
 
-	return 0;
+	return (0);
 }

--- a/usr.bin/ts/Makefile
+++ b/usr.bin/ts/Makefile
@@ -1,0 +1,12 @@
+.include <src.opts.mk>
+
+.PATH:	${SRCTOP}/contrib/ts
+
+PROG=	ts
+SRCS=	ts.c
+MAN=	ts.1
+
+HAS_TESTS=
+SUBDIR.${MK_TESTS}+=	tests
+
+.include <bsd.prog.mk>

--- a/usr.bin/ts/tests/Makefile
+++ b/usr.bin/ts/tests/Makefile
@@ -1,0 +1,5 @@
+PACKAGE=	tests
+
+ATF_TESTS_SH=	ts_test
+
+.include <bsd.test.mk>

--- a/usr.bin/ts/tests/ts_test.sh
+++ b/usr.bin/ts/tests/ts_test.sh
@@ -1,0 +1,69 @@
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+
+atf_test_case literal_format
+literal_format_head()
+{
+	atf_set "descr" "prepend a literal timestamp format to every line"
+}
+literal_format_body()
+{
+	printf "stamp alpha\nstamp beta\n" >expected
+
+	atf_check -s exit:0 -e empty -o file:expected \
+	    sh -c "printf 'alpha\\nbeta\\n' | ts stamp"
+}
+
+atf_test_case unterminated_line
+unterminated_line_head()
+{
+	atf_set "descr" "preserve an unterminated final input line"
+}
+unterminated_line_body()
+{
+	printf "stamp alpha" >expected
+
+	atf_check -s exit:0 -e empty -o file:expected \
+	    sh -c "printf alpha | ts stamp"
+}
+
+atf_test_case empty_input
+empty_input_head()
+{
+	atf_set "descr" "produce no timestamp for empty input"
+}
+empty_input_body()
+{
+	atf_check -s exit:0 -e empty -o empty ts stamp </dev/null
+}
+
+atf_test_case elapsed
+elapsed_head()
+{
+	atf_set "descr" "support elapsed timestamps with microseconds"
+}
+elapsed_body()
+{
+	atf_check -s exit:0 -e empty -o match:'^00\.[0-9]{6} alpha$' \
+	    sh -c "printf 'alpha\\n' | ts -s %.S"
+}
+
+atf_test_case conflicting_options
+conflicting_options_head()
+{
+	atf_set "descr" "reject simultaneous interval and elapsed modes"
+}
+conflicting_options_body()
+{
+	atf_check -s exit:1 -e match:usage -o empty ts -i -s
+}
+
+atf_init_test_cases()
+{
+	atf_add_test_case literal_format
+	atf_add_test_case unterminated_line
+	atf_add_test_case empty_input
+	atf_add_test_case elapsed
+	atf_add_test_case conflicting_options
+}


### PR DESCRIPTION
## Summary

- add `flock(1)` with command, shell-command, descriptor, shared/exclusive, nonblocking, and timeout modes
- add `ts(1)` with absolute, elapsed, incremental, and fractional timestamps
- add manual pages and ATF coverage and register both utilities in the userland build
- normalize the return statement in the existing `shuf(1)` implementation for style(9)

`base64(1)` and `shuf(1)` were already present after updating this branch from current master.

## Provenance

- `flock(1)` is based on the BSD-2-Clause NetBSD implementation, with MidnightBSD portability, validation, and test changes
- `ts(1)` is based on the ISC-licensed OpenBSD implementation imported by FreeBSD, with additional error handling, bounds checks, and tests

## Testing

- 24 ATF cases passed for `flock`, `ts`, `base64`, and `shuf` using host-built binaries
- strict host compilation with `-Wall -Wextra -Werror` passed
- `tools/build/checkstyle9.pl --strict` passed
- `cppcheck` passed for the changed C sources
- `sh -n` passed for the test scripts
- `mandoc -Tlint` passed apart from host manual-database lookup warnings
- `git diff --check` passed

A native MidnightBSD cross-build could not be completed because this host lacks a configured target compiler/sysroot. The repository precommit wrappers for `clang-format` and Splint could not run because those executables are not installed.

## AI contribution checklist

- [x] I have manually reviewed every line of AI-generated code for security flaws.
- [x] The code adheres to the MidnightBSD style guide (style(9)).
- [x] No proprietary or copyleft code was introduced via the AI tool.

AI-Assisted-by: OpenAI GPT-5
Obtained from: NetBSD and OpenBSD/FreeBSD

## Summary by Sourcery

Add flock(1) and ts(1) userland utilities with documentation, tests, and build integration.

New Features:
- Add flock(1) for command, shell-command, file-descriptor, lock-mode, nonblocking, and timeout-based locking.
- Add ts(1) for prefixing input lines with absolute, elapsed, incremental, and microsecond-resolution timestamps.

Enhancements:
- Provide manual pages and ATF coverage for both utilities.
- Register flock(1) and ts(1) in the userland build.
- Normalize shuf(1)'s return statement to conform to style(9).

Build:
- Add build definitions for flock(1) and ts(1).

Documentation:
- Add user-facing manual pages for flock(1) and ts(1).

Tests:
- Add ATF tests covering flock locking modes, command execution, exit status, and timeout validation.
- Add ATF tests covering ts formatting, elapsed timestamps, empty and unterminated input, and option validation.